### PR TITLE
Fix alternative route label mapping in map routing

### DIFF
--- a/client/src/MapRoute.js
+++ b/client/src/MapRoute.js
@@ -123,6 +123,7 @@ const MapRoute = () => {
           consentGiven={consentGiven}
           setMapPoints={setMapPoints}
           setRoutes={setRoutes}
+          scenarioLabel={currentScenario.label}
         />
       </MapContainer>
 

--- a/client/src/Routing.jsx
+++ b/client/src/Routing.jsx
@@ -26,6 +26,7 @@ const Routing = ({
   consentGiven,
   setMapPoints,
   setRoutes,
+  scenarioLabel,
 }) => {
   const map = useMap();
   const [localRoutes, setLocalRoutes] = useState([]);
@@ -133,7 +134,7 @@ const Routing = ({
               opacity: 1,
             }}
             eventHandlers={{
-              click: () => setSelectedLabel(i === 0 ? "default" : "alternative"),
+              click: () => setSelectedLabel(i === 0 ? "default" : scenarioLabel),
             }}
             ref={(el) => {
               if (el) polylineRefs.current[i] = el;


### PR DESCRIPTION
## Summary
- pass scenario label to map routing component
- select proper label when clicking alternative polyline

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd server && npm test` *(fails: Error: no test specified)*
- `cd client && CI=true npm test` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68ac8ebfdbb88331ae5c56f2ecf64af6