### PR TITLE
Integrate and modernize onboarding modal

### DIFF
--- a/client/src/MapRoute.js
+++ b/client/src/MapRoute.js
@@ -157,7 +157,23 @@ const MapRoute = () => {
         />
       )}
 
-      {consentGiven && (
+      {showOnboarding && (
+        <OnboardingModal
+          step={onboardingStep}
+          onNext={() => setOnboardingStep((prev) => prev + 1)}
+          onBack={() => setOnboardingStep((prev) => prev - 1)}
+          onSkip={() => {
+            setShowOnboarding(false);
+            setOnboardingStep(0);
+          }}
+          onFinish={() => {
+            setShowOnboarding(false);
+            setOnboardingStep(0);
+          }}
+        />
+      )}
+
+      {consentGiven && !showOnboarding && (
         <ScenarioPanel
           scenarioIndex={scenarioIndex}
           totalScenarios={scenarios.length}

--- a/client/src/OnboardingModal.js
+++ b/client/src/OnboardingModal.js
@@ -2,32 +2,75 @@
 
 import React from "react";
 
+const ExampleToggle = (
+  <div
+    style={{
+      width: "50px",
+      height: "28px",
+      borderRadius: "14px",
+      backgroundColor: "#ccc",
+      position: "relative",
+      margin: "12px auto 0",
+      pointerEvents: "none",
+    }}
+  >
+    <div
+      style={{
+        width: "24px",
+        height: "24px",
+        borderRadius: "50%",
+        backgroundColor: "#fff",
+        position: "absolute",
+        top: "2px",
+        left: "2px",
+      }}
+    />
+  </div>
+);
+
+const ExampleButton = (
+  <button
+    style={{
+      padding: "10px 12px",
+      backgroundColor: "#333",
+      color: "#fff",
+      border: "none",
+      borderRadius: "6px",
+      fontWeight: "bold",
+      marginTop: "8px",
+      cursor: "default",
+      pointerEvents: "none",
+    }}
+  >
+    ✅ Select & Continue
+  </button>
+);
+
 const OnboardingModal = ({ step, onNext, onBack, onSkip, onFinish }) => {
   const steps = [
     {
-      title: "Welcome!",
+      title: "Welcome",
       content: (
         <>
-          <p>
-            In this short task, you will be shown multiple routes from point A to B. One is{" "}
-            <strong>default</strong>, and others have their own features.
+          <p style={{ fontStyle: "italic" }}>
+            We'll guide you through a few quick route choices.
           </p>
-          <p>Your job is to choose the one you would take today.</p>
+          <p>
+            Each scenario compares a <strong>default</strong> path with an
+            alternative. Pick the route you'd take today.
+          </p>
         </>
       ),
     },
     {
-      title: "How to choose a route",
+      title: "Compare routes",
       content: (
         <>
-          <video
-            src="/videos/select-routes.mp4"
-            controls
-            style={{ width: "100%", borderRadius: "8px", marginBottom: "10px" }}
-          />
-          <p>
-            Click directly on the route or use the toggle panel to choose the one you prefer.
+          <p style={{ fontWeight: "bold" }}>
+            Use this switch in the panel to preview the alternative route before
+            deciding:
           </p>
+          {ExampleToggle}
         </>
       ),
     },
@@ -35,14 +78,10 @@ const OnboardingModal = ({ step, onNext, onBack, onSkip, onFinish }) => {
       title: "Submit your choice",
       content: (
         <>
-          <video
-            src="/videos/submit-choice.mp4"
-            controls
-            style={{ width: "100%", borderRadius: "8px", marginBottom: "10px" }}
-          />
-          <p>
-            When you're ready, click the <strong>✅ Go</strong> button to submit.
+          <p style={{ color: "#1452EE", fontWeight: 500 }}>
+            When you're ready, press the button below:
           </p>
+          {ExampleButton}
         </>
       ),
     },
@@ -64,20 +103,23 @@ const OnboardingModal = ({ step, onNext, onBack, onSkip, onFinish }) => {
         alignItems: "center",
         justifyContent: "center",
         padding: "20px",
+        color: "#333",
+        fontFamily: "sans-serif",
       }}
     >
       <div
         style={{
           backgroundColor: "#fff",
-          maxWidth: "600px",
+          maxWidth: "480px",
           width: "100%",
-          borderRadius: "10px",
-          padding: "20px",
-          boxShadow: "0 4px 20px rgba(0,0,0,0.3)",
+          borderRadius: "12px",
+          padding: "24px",
+          boxShadow: "0 8px 24px rgba(0,0,0,0.2)",
+          textAlign: "center",
         }}
       >
         <h2 style={{ marginTop: 0 }}>{steps[step].title}</h2>
-        <div style={{ marginBottom: "20px" }}>{steps[step].content}</div>
+        <div style={{ marginBottom: "24px", lineHeight: 1.5 }}>{steps[step].content}</div>
 
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
           <button
@@ -91,7 +133,7 @@ const OnboardingModal = ({ step, onNext, onBack, onSkip, onFinish }) => {
               textDecoration: "underline",
             }}
           >
-            Skip tutorial
+            Skip
           </button>
 
           <div>


### PR DESCRIPTION
## Summary
- Simplify onboarding flow with modern modal design and text-based instructions
- Wire onboarding modal into map route so users see it after giving consent
- Clarify onboarding copy with inert examples of the toggle and submit button

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac9f029b4883319ba5e4eb79835efa