### PR TITLE
feat(client): disable map zoom

### DIFF
--- a/client/src/MapRoute.js
+++ b/client/src/MapRoute.js
@@ -104,8 +104,14 @@ const MapRoute = () => {
       <MapContainer
         center={start}
         zoom={13}
+        minZoom={13}
+        maxZoom={13}
         style={{ height: "100%", width: "100%" }}
-        scrollWheelZoom
+        scrollWheelZoom={false}
+        doubleClickZoom={false}
+        touchZoom={false}
+        boxZoom={false}
+        keyboard={false}
         zoomControl={false}
       >
         <TileLayer


### PR DESCRIPTION
## Summary
- lock map zoom level and disable all user zoom interactions

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68accb691134833194402e6ea3bf00e6