### PR TITLE
fix: ensure scenario panel visible

### DIFF
--- a/client/src/ScenarioPanel.jsx
+++ b/client/src/ScenarioPanel.jsx
@@ -12,7 +12,7 @@ const ScenarioPanel = ({
   const isSelected = selectedLabel === label;
 
   return (
-    <div className="absolute top-5 left-5 w-72 bg-white p-5 rounded-xl shadow-lg z-50 text-sm text-gray-800 font-sans">
+    <div className="absolute top-5 left-5 w-72 bg-white p-5 rounded-xl shadow-lg z-[1000] text-sm text-gray-800 font-sans">
       <h2 className="text-lg font-semibold mb-1">
         Scenario {scenarioIndex + 1} of {totalScenarios}
       </h2>


### PR DESCRIPTION
## Summary
- ensure scenario panel overlays map by raising its z-index

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68acce194b8c8331922f20e2acf9fcfe