### PR TITLE
Disable map zoom controls in client app

### DIFF
--- a/client/src/MapRoute.js
+++ b/client/src/MapRoute.js
@@ -105,7 +105,11 @@ const MapRoute = () => {
         center={start}
         zoom={13}
         style={{ height: "100%", width: "100%" }}
-        scrollWheelZoom
+        scrollWheelZoom={false}
+        doubleClickZoom={false}
+        touchZoom={false}
+        boxZoom={false}
+        keyboard={false}
         zoomControl={false}
       >
         <TileLayer


### PR DESCRIPTION
## Summary
- Prevent user zooming by disabling scroll, touch, keyboard, and box zoom on the client map

## Testing
- `npm test -- --watchAll=false` (fails: Cannot find module 'react-router-dom' from 'src/App.js')

------
https://chatgpt.com/codex/tasks/task_e_68acce2f740c83318e86346d2c1b51ce