### PR TITLE
Disable map zoom controls in client app

### DIFF
--- a/client/src/MapRoute.js
+++ b/client/src/MapRoute.js
@@ -104,8 +104,14 @@ const MapRoute = () => {
       <MapContainer
         center={start}
         zoom={13}
+        minZoom={13}
+        maxZoom={13}
         style={{ height: "100%", width: "100%" }}
-        scrollWheelZoom
+        scrollWheelZoom={false}
+        doubleClickZoom={false}
+        touchZoom={false}
+        boxZoom={false}
+        keyboard={false}
         zoomControl={false}
       >
         <TileLayer


### PR DESCRIPTION
## Summary
- Lock map zoom level by setting minZoom and maxZoom to prevent any zooming

## Testing
- `npm test -- --watchAll=false` (fails: Cannot find module 'react-router-dom' from 'src/App.js')


------
https://chatgpt.com/codex/tasks/task_e_68acce2f740c83318e86346d2c1b51ce