### PR TITLE
Disable map zoom controls in client app

### DIFF
--- a/client/src/MapRoute.js
+++ b/client/src/MapRoute.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { MapContainer, TileLayer } from "react-leaflet";
+import { MapContainer, TileLayer, useMap } from "react-leaflet";
 import Routing from "./Routing";
 import RoutingLabels from "./RoutingLabels";
 import OnboardingModal from "./OnboardingModal";
@@ -7,6 +7,21 @@ import ConsentModal from "./ConsentModal";
 import ScenarioPanel from "./ScenarioPanel";
 import { v4 as uuidv4 } from "uuid";
 import { useNavigate } from "react-router-dom";
+
+const DisableMapZoom = () => {
+  const map = useMap();
+
+  useEffect(() => {
+    map.scrollWheelZoom.disable();
+    map.doubleClickZoom.disable();
+    map.touchZoom.disable();
+    map.boxZoom.disable();
+    map.keyboard.disable();
+    map.zoomControl.remove();
+  }, [map]);
+
+  return null;
+};
 
 const MapRoute = () => {
   const [routeConfig, setRouteConfig] = useState(null);
@@ -104,10 +119,17 @@ const MapRoute = () => {
       <MapContainer
         center={start}
         zoom={13}
+        minZoom={13}
+        maxZoom={13}
         style={{ height: "100%", width: "100%" }}
-        scrollWheelZoom
+        scrollWheelZoom={false}
+        doubleClickZoom={false}
+        touchZoom={false}
+        boxZoom={false}
+        keyboard={false}
         zoomControl={false}
       >
+        <DisableMapZoom />
         <TileLayer
           attribution='&copy; <a href="https://carto.com/">CARTO</a>'
           url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"


### PR DESCRIPTION
## Summary
- Introduce helper component that programmatically disables scroll, touch, and control-based zoom interactions
- Render helper inside MapRoute so trackpad gestures can no longer change zoom level

## Testing
- `npm test -- --watchAll=false` (fails: Cannot find module 'react-router-dom' from 'src/App.js`)

------
https://chatgpt.com/codex/tasks/task_e_68acce2f740c83318e86346d2c1b51ce