### PR TITLE
Add top progress bar for scenario steps

### DIFF
--- a/client/src/MapRoute.js
+++ b/client/src/MapRoute.js
@@ -5,6 +5,7 @@ import RoutingLabels from "./RoutingLabels";
 import OnboardingModal from "./OnboardingModal";
 import ConsentModal from "./ConsentModal";
 import ScenarioPanel from "./ScenarioPanel";
+import ProgressBar from "./ProgressBar";
 import { v4 as uuidv4 } from "uuid";
 import { useNavigate } from "react-router-dom";
 
@@ -106,6 +107,7 @@ const MapRoute = () => {
 
   return (
     <div style={{ position: "relative", width: "100vw", height: "100vh" }}>
+      <ProgressBar currentStep={scenarioIndex} totalSteps={scenarios.length} />
       <MapContainer
         center={start}
         zoom={13}
@@ -186,8 +188,6 @@ const MapRoute = () => {
 
       {consentGiven && !showOnboarding && (
         <ScenarioPanel
-          scenarioIndex={scenarioIndex}
-          totalScenarios={scenarios.length}
           label={currentScenario.label}
           description={routeDict[currentScenario.routeName].description}
           selectedLabel={selectedLabel}

--- a/client/src/ProgressBar.jsx
+++ b/client/src/ProgressBar.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+const ProgressBar = ({ currentStep, totalSteps }) => {
+  const percentage = ((currentStep + 1) / totalSteps) * 100;
+
+  return (
+    <div className="absolute top-0 left-0 w-full h-2 bg-gray-200 z-[1000]">
+      <div
+        className="h-full bg-blue-600 transition-all duration-300"
+        style={{ width: `${percentage}%` }}
+      />
+    </div>
+  );
+};
+
+export default ProgressBar;
+

--- a/client/src/ScenarioPanel.jsx
+++ b/client/src/ScenarioPanel.jsx
@@ -1,21 +1,10 @@
 import React from "react";
 
-const ScenarioPanel = ({
-  scenarioIndex,
-  totalScenarios,
-  label,
-  description,
-  selectedLabel,
-  onToggle,
-  onSubmit,
-}) => {
+const ScenarioPanel = ({ label, description, selectedLabel, onToggle, onSubmit }) => {
   const isSelected = selectedLabel === label;
 
   return (
     <div className="absolute top-5 left-5 w-72 bg-white p-5 rounded-xl shadow-lg z-[1000] text-sm text-gray-800 font-sans">
-      <h2 className="text-lg font-semibold mb-1">
-        Scenario {scenarioIndex + 1} of {totalScenarios}
-      </h2>
       <p className="text-gray-600">Choose your preferred route to continue.</p>
 
       <div className="mt-4 space-y-4">


### PR DESCRIPTION
## Summary
- add a top-aligned progress bar that fills as scenarios advance
- remove scenario count from panel and rely on the new progress bar

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68acdb1116d08331bc48d6c1faca10f1