### PR TITLE
Add top progress bar for scenario steps

### DIFF
--- a/client/src/MapRoute.js
+++ b/client/src/MapRoute.js
@@ -5,6 +5,7 @@ import RoutingLabels from "./RoutingLabels";
 import OnboardingModal from "./OnboardingModal";
 import ConsentModal from "./ConsentModal";
 import ScenarioPanel from "./ScenarioPanel";
+import ProgressBar from "./ProgressBar";
 import { v4 as uuidv4 } from "uuid";
 import { useNavigate } from "react-router-dom";
 
@@ -106,6 +107,7 @@ const MapRoute = () => {
 
   return (
     <div style={{ position: "relative", width: "100vw", height: "100vh" }}>
+      <ProgressBar currentStep={scenarioIndex} totalSteps={scenarios.length} />
       <MapContainer
         center={start}
         zoom={13}

--- a/client/src/ProgressBar.jsx
+++ b/client/src/ProgressBar.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+const ProgressBar = ({ currentStep, totalSteps }) => {
+  const percentage = ((currentStep + 1) / totalSteps) * 100;
+
+  return (
+    <div className="absolute top-0 left-0 w-full h-2 bg-gray-200 z-[1000]">
+      <div
+        className="h-full bg-blue-600 transition-all duration-300"
+        style={{ width: `${percentage}%` }}
+      />
+    </div>
+  );
+};
+
+export default ProgressBar;
+


### PR DESCRIPTION
## Summary
- add a top-aligned progress bar that fills as scenarios advance
- keep scenario progress text inside the panel for clarity

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68acdb1116d08331bc48d6c1faca10f1