### PR TITLE
Show progress after onboarding and display scenario count

### DIFF
--- a/client/src/MapRoute.js
+++ b/client/src/MapRoute.js
@@ -107,7 +107,9 @@ const MapRoute = () => {
 
   return (
     <div style={{ position: "relative", width: "100vw", height: "100vh" }}>
-      <ProgressBar currentStep={scenarioIndex} totalSteps={scenarios.length} />
+      {consentGiven && !showOnboarding && (
+        <ProgressBar currentStep={scenarioIndex} totalSteps={scenarios.length} />
+      )}
       <MapContainer
         center={start}
         zoom={13}
@@ -197,6 +199,8 @@ const MapRoute = () => {
             )
           }
           onSubmit={() => handleChoice(selectedLabel)}
+          scenarioNumber={scenarioIndex + 1}
+          totalScenarios={scenarios.length}
         />
       )}
     </div>

--- a/client/src/ScenarioPanel.jsx
+++ b/client/src/ScenarioPanel.jsx
@@ -1,10 +1,19 @@
 import React from "react";
 
-const ScenarioPanel = ({ label, description, selectedLabel, onToggle, onSubmit }) => {
+const ScenarioPanel = ({
+  label,
+  description,
+  selectedLabel,
+  onToggle,
+  onSubmit,
+  scenarioNumber,
+  totalScenarios,
+}) => {
   const isSelected = selectedLabel === label;
 
   return (
     <div className="absolute top-5 left-5 w-72 bg-white p-5 rounded-xl shadow-lg z-[1000] text-sm text-gray-800 font-sans">
+      <p className="font-semibold">Scenario {scenarioNumber} out of {totalScenarios}</p>
       <p className="text-gray-600">Choose your preferred route to continue.</p>
 
       <div className="mt-4 space-y-4">


### PR DESCRIPTION
## Summary
- Display progress bar only after consent and onboarding modals are closed
- Show current scenario count within the selection panel

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68acdff3dc8c8331b8551b25ddb69226