### PR TITLE
feat(client): polish map markers and labels

### DIFF
--- a/client/src/Routing.jsx
+++ b/client/src/Routing.jsx
@@ -3,17 +3,30 @@ import { useMap, Polyline, Marker } from "react-leaflet";
 import L from "leaflet";
 import "leaflet-routing-machine";
 
-const carIcon = new L.Icon({
-  iconUrl: "https://cdn-icons-png.flaticon.com/512/744/744465.png",
-  iconSize: [40, 40],
-  iconAnchor: [20, 20],
-});
+const createPinIcon = (color, path) =>
+  L.divIcon({
+    className: "",
+    iconSize: [40, 40],
+    iconAnchor: [20, 40],
+    html: `
+      <svg width="40" height="40" viewBox="0 0 24 24">
+        <path fill="${color}" d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z"/>
+        <g transform="translate(4,4) scale(0.67)" fill="#fff">
+          <path d="${path}" />
+        </g>
+      </svg>
+    `,
+  });
 
-const flagIcon = new L.Icon({
-  iconUrl: "https://cdn-icons-png.flaticon.com/512/684/684908.png",
-  iconSize: [40, 40],
-  iconAnchor: [20, 40],
-});
+const carIcon = createPinIcon(
+  "#4285F4",
+  "M18.92 5.01C18.72 4.42 18.16 4 17.5 4h-11c-.66 0-1.23.42-1.43 1.01L3 11v7c0 .55.45 1 1 1h1c.55 0 1-.45 1-1v-1h10v1c0 .55.45 1 1 1h1c.55 0 1-.45 1-1v-7l-1.08-5.99zM6.85 6h10.29l1.04 3H5.81l1.04-3zM5 16v-3h14v3H5z"
+);
+
+const flagIcon = createPinIcon(
+  "#EA4335",
+  "M14.4 5l-.24-1.2C14.04 3.34 13.66 3 13.23 3H6v16h2v-6h5.17c.43 0 .81-.34.89-.78L14.4 5z"
+);
 
 const Routing = ({
   from,

--- a/client/src/RoutingLabels.jsx
+++ b/client/src/RoutingLabels.jsx
@@ -10,28 +10,43 @@ const RoutingLabels = ({ mapPoints, routes }) => {
             key={`label-${i}`}
             style={{
               position: "absolute",
-              left: pt.x + 8,
-              top: pt.y - 20,
-              background: "#fff",
-              border: "1px solid #ccc",
-              borderRadius: "4px",
-              padding: "4px 6px",
-              fontSize: "12px",
-              fontFamily: "sans-serif",
-              color: "#333",
-              boxShadow: "0 1px 3px rgba(0,0,0,0.2)",
-              width: "80px",
+              left: pt.x,
+              top: pt.y,
+              transform: "translate(-50%, -100%)",
               pointerEvents: "none",
+              fontFamily: "Roboto, sans-serif",
+              fontSize: "13px",
+              color: "#202124",
             }}
           >
-            <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+            <div
+              style={{
+                background: "#fff",
+                borderRadius: "4px",
+                padding: "4px 8px",
+                boxShadow: "0 2px 6px rgba(0,0,0,0.3)",
+                display: "flex",
+                alignItems: "center",
+                gap: "4px",
+                fontWeight: 500,
+              }}
+            >
               <svg width="16" height="16" viewBox="0 0 24 24" fill="#5f6368">
-                <path d="M5 11h14l-1.5-4.5h-11L5 11zm0 2c-.6 0-1 .4-1 1v6h2v-2h12v2h2v-6c0-.6-.4-1-1-1H5zm3.5 3c-.8 0-1.5-.7-1.5-1.5S7.7 13 8.5 13s1.5.7 1.5 1.5S9.3 16 8.5 16zm7 0c-.8 0-1.5-.7-1.5-1.5S14.7 13 15.5 13s1.5.7 1.5 1.5S16.3 16 15.5 16z" />
+                <path d="M18.92 5.01C18.72 4.42 18.16 4 17.5 4h-11c-.66 0-1.23.42-1.43 1.01L3 11v7c0 .55.45 1 1 1h1c.55 0 1-.45 1-1v-1h10v1c0 .55.45 1 1 1h1c.55 0 1-.45 1-1v-7l-1.08-5.99zM6.85 6h10.29l1.04 3H5.81l1.04-3zM5 16v-3h14v3H5z" />
               </svg>
-              <span style={{ fontWeight: "bold", fontSize: "13px" }}>
-                {route.totalTimeMinutes} min
-              </span>
+              <span>{route.totalTimeMinutes} min</span>
             </div>
+            <div
+              style={{
+                width: 0,
+                height: 0,
+                margin: "0 auto",
+                borderLeft: "6px solid transparent",
+                borderRight: "6px solid transparent",
+                borderTop: "6px solid #fff",
+                boxShadow: "0 2px 6px rgba(0,0,0,0.3)",
+              }}
+            />
           </div>
         );
       })}


### PR DESCRIPTION
## Summary
- replace flaticon images with custom SVG pin markers for start and finish
- restyle routing info boxes to resemble modern map popups

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68ace8c1227c833184fd431dc24a9591