### PR TITLE
Clarify start and end map markers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/node_modules/

--- a/client/src/Routing.jsx
+++ b/client/src/Routing.jsx
@@ -3,7 +3,7 @@ import { useMap, Polyline, Marker } from "react-leaflet";
 import L from "leaflet";
 import "leaflet-routing-machine";
 
-const createPinIcon = (color, path) =>
+const createTextPinIcon = (color, label) =>
   L.divIcon({
     className: "",
     iconSize: [40, 40],
@@ -11,22 +11,13 @@ const createPinIcon = (color, path) =>
     html: `
       <svg width="40" height="40" viewBox="0 0 24 24">
         <path fill="${color}" d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z"/>
-        <g transform="translate(4,4) scale(0.67)" fill="#fff">
-          <path d="${path}" />
-        </g>
+        <text x="12" y="16" text-anchor="middle" font-size="10" font-family="Arial" font-weight="bold" fill="#fff">${label}</text>
       </svg>
     `,
   });
 
-const carIcon = createPinIcon(
-  "#4285F4",
-  "M18.92 5.01C18.72 4.42 18.16 4 17.5 4h-11c-.66 0-1.23.42-1.43 1.01L3 11v7c0 .55.45 1 1 1h1c.55 0 1-.45 1-1v-1h10v1c0 .55.45 1 1 1h1c.55 0 1-.45 1-1v-7l-1.08-5.99zM6.85 6h10.29l1.04 3H5.81l1.04-3zM5 16v-3h14v3H5z"
-);
-
-const flagIcon = createPinIcon(
-  "#EA4335",
-  "M14.4 5l-.24-1.2C14.04 3.34 13.66 3 13.23 3H6v16h2v-6h5.17c.43 0 .81-.34.89-.78L14.4 5z"
-);
+const startIcon = createTextPinIcon("#34A853", "S");
+const endIcon = createTextPinIcon("#EA4335", "E");
 
 const Routing = ({
   from,
@@ -140,8 +131,8 @@ const Routing = ({
 
   return (
     <>
-      <Marker position={from} icon={carIcon} />
-      <Marker position={to} icon={flagIcon} />
+      <Marker position={from} icon={startIcon} />
+      <Marker position={to} icon={endIcon} />
 
       {localRoutes.map((route, i) =>
         route?.coords ? (


### PR DESCRIPTION
## Summary
- replace unclear start/end car and flag icons with green "S" and red "E" pins for clarity
- ignore all node_modules directories in git

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68aceac4699c8331b1e00df2dc7369cf