### PR TITLE
feat: auto zoom map to fit routes

### DIFF
--- a/client/src/MapRoute.js
+++ b/client/src/MapRoute.js
@@ -113,8 +113,6 @@ const MapRoute = () => {
       <MapContainer
         center={start}
         zoom={13}
-        minZoom={13}
-        maxZoom={13}
         style={{ height: "100%", width: "100%" }}
         scrollWheelZoom={false}
         doubleClickZoom={false}

--- a/client/src/Routing.jsx
+++ b/client/src/Routing.jsx
@@ -77,6 +77,11 @@ const Routing = ({
 
         if (newRoutes.filter(Boolean).length === waypointsList.length) {
           setLocalRoutes([...newRoutes]);
+          const allCoords = newRoutes.flatMap((r) => (r?.coords ? r.coords : []));
+          if (allCoords.length) {
+            const bounds = L.latLngBounds(allCoords);
+            map.fitBounds(bounds, { padding: [50, 50], maxZoom: 15 });
+          }
         }
       });
 


### PR DESCRIPTION
## Summary
- allow map zoom to adjust dynamically to route bounds
- auto-fit bounds around routes with padding for balanced view

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68acf62114808331902e28cf747a3d65