### PR TITLE
fix: specify workspace root for Next.js output tracing

### DIFF
--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -1,8 +1,11 @@
 import type { NextConfig } from 'next'
- 
+import path from 'path'
+
 const nextConfig: NextConfig = {
   output: 'export', // Outputs a Single-Page Application (SPA)
   distDir: 'build', // Changes the build output directory to `build`
+  outputFileTracingRoot: path.join(__dirname, '..'),
 }
- 
+
 export default nextConfig
+


### PR DESCRIPTION
## Summary
- specify workspace root to silence Next.js lockfile warning

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b49fc09980833180024415674fab43