### PR TITLE
Suppress hydration mismatch error in Next.js layout

### DIFF
--- a/client/app/layout.js
+++ b/client/app/layout.js
@@ -3,7 +3,7 @@ import "../src/index.css";
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body suppressHydrationWarning>{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- ignore extension-injected attributes during hydration by enabling `suppressHydrationWarning` on `<body>`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b49fed47d08331b4a5981d9b6b2881