### PR TITLE
feat: initialize map with route bounds

### DIFF
--- a/client/src/MapRoute.js
+++ b/client/src/MapRoute.js
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import { MapContainer, TileLayer } from "react-leaflet";
+import L from "leaflet";
 import Routing from "./Routing";
 import RoutingLabels from "./RoutingLabels";
 import OnboardingModal from "./OnboardingModal";
@@ -100,6 +101,11 @@ const MapRoute = () => {
   const { start, end, routes: routeDict, consentText } = routeConfig;
   const currentScenario = scenarios[scenarioIndex];
   const defaultTime = routeDict.default.totalTimeMinutes;
+  const bounds = useMemo(() => {
+    const pts = [start, end];
+    if (currentScenario?.middle) pts.push(currentScenario.middle);
+    return L.latLngBounds(pts);
+  }, [start, end, currentScenario]);
 
   return (
     <div style={{ position: "relative", width: "100vw", height: "100vh" }}>
@@ -107,8 +113,8 @@ const MapRoute = () => {
         <ProgressBar currentStep={scenarioIndex} totalSteps={scenarios.length} />
       )}
       <MapContainer
-        center={start}
-        zoom={13}
+        bounds={bounds}
+        boundsOptions={{ padding: [50, 50], maxZoom: 15 }}
         style={{ height: "100%", width: "100%" }}
         scrollWheelZoom={false}
         doubleClickZoom={false}

--- a/client/src/Routing.jsx
+++ b/client/src/Routing.jsx
@@ -80,7 +80,7 @@ const Routing = ({
           const allCoords = newRoutes.flatMap((r) => (r?.coords ? r.coords : []));
           if (allCoords.length) {
             const bounds = L.latLngBounds(allCoords);
-            map.fitBounds(bounds, { padding: [50, 50], maxZoom: 15 });
+            map.fitBounds(bounds, { padding: [50, 50], maxZoom: 15, animate: false });
           }
         }
       });


### PR DESCRIPTION
## Summary
- fit leaflet MapContainer to route start/end/middle points to remove hard-coded zoom
- disable animated bounds fitting when routes load to prevent zooming transitions

## Testing
- `npm test`
- `cd client && npm test`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a876dd948331bae69c7ecb3fb217