### PR TITLE
fix: maintain stable hook order in MapRoute

### DIFF
--- a/client/src/MapRoute.js
+++ b/client/src/MapRoute.js
@@ -95,17 +95,19 @@ const MapRoute = () => {
     }
   };
 
-  if (error) return <div>{error}</div>;
-  if (!routeConfig || scenarios.length === 0) return <div>Loading route data...</div>;
-
-  const { start, end, routes: routeDict, consentText } = routeConfig;
+  const { start, end, routes: routeDict, consentText } = routeConfig || {};
   const currentScenario = scenarios[scenarioIndex];
-  const defaultTime = routeDict.default.totalTimeMinutes;
+  const defaultTime = routeDict?.default?.totalTimeMinutes;
   const bounds = useMemo(() => {
+    if (!start || !end) return null;
     const pts = [start, end];
     if (currentScenario?.middle) pts.push(currentScenario.middle);
     return L.latLngBounds(pts);
   }, [start, end, currentScenario]);
+
+  if (error) return <div>{error}</div>;
+  if (!routeConfig || scenarios.length === 0 || !bounds)
+    return <div>Loading route data...</div>;
 
   return (
     <div style={{ position: "relative", width: "100vw", height: "100vh" }}>


### PR DESCRIPTION
## Summary
- ensure MapRoute hooks are called in a consistent order
- guard bounds calculation until route data is ready

## Testing
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a9a20170833197f9252bcdaf7587