### PR TITLE
Use PATCH for selective config updates

### DIFF
--- a/admin/src/AdminApp.jsx
+++ b/admin/src/AdminApp.jsx
@@ -58,12 +58,17 @@ export default function AdminApp() {
     setSaving(true);
     setError("");
     try {
-      // Only send fields managed by the admin UI to avoid overwriting
-      // manual edits in the config file (e.g., consent text).
-      const { consentText, ...payload } = config || {};
+      // Send only the fields that the admin UI is allowed to modify
+      const { start, end, routes, numberOfScenarios } = config || {};
+      const payload = {};
+      if (start !== undefined) payload.start = start;
+      if (end !== undefined) payload.end = end;
+      if (routes !== undefined) payload.routes = routes;
+      if (numberOfScenarios !== undefined)
+        payload.numberOfScenarios = numberOfScenarios;
 
       const res = await fetch(API_URL, {
-        method: "POST",
+        method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
       });

--- a/server/index.js
+++ b/server/index.js
@@ -141,6 +141,70 @@ app.post("/api/route-endpoints", (req, res) => {
   });
 });
 
+// 🔹 PATCH: Update specific config fields
+app.patch("/api/route-endpoints", (req, res) => {
+  const incoming = req.body || {};
+  const allowed = {};
+
+  if (Object.prototype.hasOwnProperty.call(incoming, "start")) {
+    if (!Array.isArray(incoming.start)) {
+      return res.status(400).json({ error: "Invalid start format" });
+    }
+    allowed.start = incoming.start;
+  }
+  if (Object.prototype.hasOwnProperty.call(incoming, "end")) {
+    if (!Array.isArray(incoming.end)) {
+      return res.status(400).json({ error: "Invalid end format" });
+    }
+    allowed.end = incoming.end;
+  }
+  if (Object.prototype.hasOwnProperty.call(incoming, "routes")) {
+    if (typeof incoming.routes !== "object") {
+      return res.status(400).json({ error: "Invalid routes format" });
+    }
+    allowed.routes = incoming.routes;
+  }
+  if (Object.prototype.hasOwnProperty.call(incoming, "numberOfScenarios")) {
+    if (typeof incoming.numberOfScenarios !== "number") {
+      return res
+        .status(400)
+        .json({ error: "Invalid numberOfScenarios format" });
+    }
+    allowed.numberOfScenarios = incoming.numberOfScenarios;
+  }
+
+  if (Object.keys(allowed).length === 0) {
+    return res.status(400).json({ error: "No valid fields provided" });
+  }
+
+  fs.readFile(configPath, "utf8", (readErr, data) => {
+    if (readErr && readErr.code !== "ENOENT") {
+      console.error("Error reading existing config:", readErr);
+      return res.status(500).json({ error: "Failed to read existing config" });
+    }
+
+    let existing = {};
+    if (!readErr) {
+      try {
+        existing = JSON.parse(data);
+      } catch (e) {
+        console.error("Invalid JSON in existing config:", e);
+      }
+    }
+
+    const merged = { ...existing, ...allowed };
+
+    fs.writeFile(configPath, JSON.stringify(merged, null, 2), (err) => {
+      if (err) {
+        console.error("Error writing appConfig.json:", err);
+        return res.status(500).json({ error: "Failed to write config file" });
+      }
+
+      res.json({ success: true });
+    });
+  });
+});
+
 app.listen(PORT, () => {
   console.log(`Server running at http://localhost:${PORT}`);
 });


### PR DESCRIPTION
## Summary
- Allow server to PATCH specific config fields (start, end, routes, numberOfScenarios) instead of overwriting whole file
- Update admin save logic to send PATCH with only permitted fields

## Testing
- `npm test` (root) *(fails: Missing script)*
- `npm test` in admin *(No tests)*
- `node server/index.js`

------
https://chatgpt.com/codex/tasks/task_e_68b4aa0020bc8331908055333348bdd3