### PR TITLE
Handle invalid scenario count

### DIFF
--- a/client/src/MapRoute.js
+++ b/client/src/MapRoute.js
@@ -63,7 +63,11 @@ const MapRoute = () => {
     }
 
     const shuffled = variants.sort(() => Math.random() - 0.5);
-    return shuffled.slice(0, config.numberOfScenarios);
+    const maxScenarios =
+      typeof config.numberOfScenarios === "number" && config.numberOfScenarios > 0
+        ? config.numberOfScenarios
+        : variants.length;
+    return shuffled.slice(0, Math.min(maxScenarios, variants.length));
   };
 
   const handleChoice = async (label) => {


### PR DESCRIPTION
## Summary
- Avoid infinite loading when `numberOfScenarios` is zero or negative by defaulting to available routes

## Testing
- `npm test` (client)
- `npm test` (server) *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b478fe488331b79e5dd234267533