### PR TITLE
Add session-based admin login

### DIFF
--- a/client/app/admin/login/page.js
+++ b/client/app/admin/login/page.js
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function AdminLogin() {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const router = useRouter();
+
+  const submit = async (e) => {
+    e.preventDefault();
+    setError("");
+    const res = await fetch("http://localhost:5000/api/admin/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ username, password }),
+    });
+    if (res.ok) {
+      router.replace("/admin/routes");
+    } else {
+      setError("Invalid credentials");
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen p-4">
+      <form onSubmit={submit} className="border p-6 rounded w-full max-w-sm space-y-4">
+        <h1 className="text-xl font-semibold">Admin Login</h1>
+        {error && <div className="text-sm text-red-600">{error}</div>}
+        <input
+          type="text"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          className="w-full border px-3 py-2 rounded"
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full border px-3 py-2 rounded"
+        />
+        <button type="submit" className="w-full bg-indigo-600 text-white py-2 rounded">
+          Login
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/client/middleware.ts
+++ b/client/middleware.ts
@@ -2,18 +2,17 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 export function middleware(req: NextRequest) {
-  const auth = req.headers.get("authorization") || "";
-  const [type, encoded] = auth.split(" ");
-  if (type === "Basic") {
-    const [user, pass] = Buffer.from(encoded, "base64").toString().split(":");
-    if (user === "admin" && pass === "admin") {
-      return NextResponse.next();
-    }
+  const { pathname } = req.nextUrl;
+  if (pathname === "/admin/login") {
+    return NextResponse.next();
   }
-  return new NextResponse("Authentication required.", {
-    status: 401,
-    headers: { "WWW-Authenticate": 'Basic realm="admin"' },
-  });
+  const authed = req.cookies.get("adminAuth")?.value === "1";
+  if (authed) {
+    return NextResponse.next();
+  }
+  const url = req.nextUrl.clone();
+  url.pathname = "/admin/login";
+  return NextResponse.redirect(url);
 }
 
 export const config = {

--- a/client/src/admin/AdminApp.jsx
+++ b/client/src/admin/AdminApp.jsx
@@ -17,7 +17,6 @@ export const useConfig = () => {
 const API_URL = "http://localhost:5000/api/route-endpoints";
 
 export default function AdminApp() {
-  const authHeader = "Basic " + btoa("admin:admin");
   const [config, setConfig] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -46,7 +45,7 @@ export default function AdminApp() {
     setLoading(true);
     try {
       const res = await fetch(API_URL, {
-        headers: { Authorization: authHeader },
+        credentials: "include",
       });
       if (!res.ok) throw new Error(`Failed to load config (${res.status})`);
       const data = await res.json();
@@ -77,8 +76,8 @@ export default function AdminApp() {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",
-          Authorization: authHeader,
         },
+        credentials: "include",
         body: JSON.stringify(payload),
       });
       if (!res.ok) throw new Error(`Failed to save (${res.status})`);
@@ -112,6 +111,14 @@ export default function AdminApp() {
   const linkClass = (slug) =>
     `px-2 py-1 rounded ${section === slug ? "bg-white border" : "hover:underline"}`;
 
+  const logout = async () => {
+    await fetch("http://localhost:5000/api/admin/logout", {
+      method: "POST",
+      credentials: "include",
+    });
+    router.replace("/admin/login");
+  };
+
   if (loading) return <div className="p-6 text-sm text-gray-600">Loading…</div>;
 
   return (
@@ -130,6 +137,7 @@ export default function AdminApp() {
           <button onClick={save} disabled={!dirty || saving} className="bg-indigo-600 text-white px-3 py-1 rounded disabled:opacity-50">
             {saving ? "Saving…" : "Save"}
           </button>
+          <button onClick={logout} className="border px-3 py-1 rounded">Logout</button>
         </div>
       </header>
       {error && (


### PR DESCRIPTION
## Summary
- replace basic auth middleware with cookie-based session checks
- add dedicated admin login page and logout button
- secure server endpoints with session cookie and login/logout routes

## Testing
- `cd server && npm test`
- `cd ../client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdd0614f8883319a81fc456ba1e918