### PR TITLE
Integrate scenario settings and add map previews

### DIFF
--- a/client/src/admin/AdminApp.jsx
+++ b/client/src/admin/AdminApp.jsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import ScenariosEditor from "./ScenariosEditor";
 import SurveyEditor from "./SurveyEditor";
-import SettingsEditor from "./SettingsEditor";
 import { validateScenarioConfig } from "./validateScenarios";
 
 // ---- Config context
@@ -108,8 +107,8 @@ export default function AdminApp() {
   const section = pathname.split("/").pop();
 
   useEffect(() => {
-    if (!section || !["settings", "scenarios", "survey"].includes(section)) {
-      router.replace("/admin/settings");
+    if (!section || !["scenarios", "survey"].includes(section)) {
+      router.replace("/admin/scenarios");
     }
   }, [section, router]);
 
@@ -130,7 +129,6 @@ export default function AdminApp() {
     <ConfigContext.Provider value={ctxValue}>
       <header className="flex items-center justify-between p-4 border-b bg-gray-50">
         <nav className="flex gap-4">
-          <Link href="/admin/settings" className={linkClass("settings")}>Settings</Link>
           <Link href="/admin/scenarios" className={linkClass("scenarios")}>Scenarios</Link>
           <Link href="/admin/survey" className={linkClass("survey")}>Survey</Link>
         </nav>
@@ -150,7 +148,6 @@ export default function AdminApp() {
         <div className="m-4 border rounded p-3 text-sm bg-red-50 border-red-200 text-red-800">{error}</div>
       )}
       <main className="p-4">
-        {section === "settings" && <SettingsEditor />}
         {section === "scenarios" && <ScenariosEditor />}
         {section === "survey" && <SurveyEditor />}
       </main>

--- a/client/src/admin/ScenarioMapPreview.jsx
+++ b/client/src/admin/ScenarioMapPreview.jsx
@@ -1,0 +1,131 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { MapContainer, TileLayer, Marker, Polyline, useMap } from "react-leaflet";
+import L from "leaflet";
+import "leaflet-routing-machine";
+
+function Routes({ scenario }) {
+  const map = useMap();
+  const [routes, setRoutes] = useState([]);
+
+  useEffect(() => {
+    if (!map || !scenario) return;
+
+    const start = Array.isArray(scenario.start?.[0]) ? scenario.start[0] : null;
+    const end = Array.isArray(scenario.end?.[0]) ? scenario.end[0] : null;
+    if (!start || !end) return;
+
+    const waypointSets = [
+      [L.latLng(start[0], start[1]), L.latLng(end[0], end[1])],
+    ];
+
+    const choices = Array.isArray(scenario.choice_list) ? scenario.choice_list : [];
+    choices.forEach((ch) => {
+      const mid = Array.isArray(ch.middle_point?.[0]) ? ch.middle_point[0] : null;
+      if (mid) {
+        waypointSets.push([
+          L.latLng(start[0], start[1]),
+          L.latLng(mid[0], mid[1]),
+          L.latLng(end[0], end[1]),
+        ]);
+      }
+    });
+
+    const controls = [];
+    const newRoutes = [];
+
+    waypointSets.forEach((wps, idx) => {
+      const control = L.Routing.control({
+        waypoints: wps,
+        routeWhileDragging: false,
+        draggableWaypoints: false,
+        addWaypoints: false,
+        show: false,
+        fitSelectedRoutes: false,
+        createMarker: () => null,
+        lineOptions: { styles: [] },
+      }).addTo(map);
+
+      control.on("routesfound", (e) => {
+        newRoutes[idx] = e.routes[0].coordinates.map((c) => [c.lat, c.lng]);
+        if (newRoutes.filter(Boolean).length === waypointSets.length) {
+          setRoutes([...newRoutes]);
+          const allCoords = newRoutes.flatMap((r) => (r ? r : []));
+          if (allCoords.length) {
+            const bounds = L.latLngBounds(allCoords);
+            map.fitBounds(bounds, { padding: [20, 20], maxZoom: 15, animate: false });
+          }
+        }
+      });
+
+      controls.push(control);
+    });
+
+    return () => {
+      controls.forEach((ctrl) => {
+        ctrl.off();
+        if (ctrl.getRouter && typeof ctrl.getRouter().abort === "function") {
+          ctrl.getRouter().abort();
+        }
+        map.removeControl(ctrl);
+      });
+      setRoutes([]);
+    };
+  }, [map, scenario]);
+
+  const start = Array.isArray(scenario.start?.[0]) ? scenario.start[0] : null;
+  const end = Array.isArray(scenario.end?.[0]) ? scenario.end[0] : null;
+
+  return (
+    <>
+      {start && <Marker position={start} />}
+      {end && <Marker position={end} />}
+      {routes.map(
+        (coords, i) =>
+          coords && (
+            <Polyline
+              key={i}
+              positions={coords}
+              pathOptions={{
+                color: i === 0 ? "#1452EE" : "#BCCEFB",
+                weight: i === 0 ? 7 : 5,
+                opacity: 1,
+              }}
+            />
+          )
+      )}
+    </>
+  );
+}
+
+export default function ScenarioMapPreview({ scenario }) {
+  const start = Array.isArray(scenario?.start?.[0]) ? scenario.start[0] : null;
+  const end = Array.isArray(scenario?.end?.[0]) ? scenario.end[0] : null;
+  if (!start || !end) return null;
+
+  const bounds = L.latLngBounds([start, end]);
+
+  return (
+    <div className="h-64 w-full">
+      <MapContainer
+        bounds={bounds}
+        boundsOptions={{ padding: [20, 20], maxZoom: 15 }}
+        style={{ height: "100%", width: "100%" }}
+        scrollWheelZoom={false}
+        doubleClickZoom={false}
+        touchZoom={false}
+        boxZoom={false}
+        keyboard={false}
+        zoomControl={false}
+      >
+        <TileLayer
+          attribution='&copy; <a href="https://carto.com/">CARTO</a>'
+          url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+        />
+        <Routes scenario={scenario} />
+      </MapContainer>
+    </div>
+  );
+}
+

--- a/client/src/admin/ScenariosEditor.jsx
+++ b/client/src/admin/ScenariosEditor.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 import { useConfig } from "./AdminApp";
+import SettingsEditor from "./SettingsEditor";
+import ScenarioMapPreview from "./ScenarioMapPreview";
 
 function CoordPairInput({ label, value, onChange }) {
   const pair = Array.isArray(value) && Array.isArray(value[0]) ? value[0] : [0, 0];
@@ -222,14 +224,18 @@ export default function ScenariosEditor() {
           ))}
         </div>
       </aside>
-      <main className="flex-1 p-4 overflow-y-auto">
+      <main className="flex-1 p-4 overflow-y-auto space-y-6">
+        <SettingsEditor />
         {selected ? (
-          <ScenarioForm
-            scenario={selected}
-            index={selectedIdx}
-            onChange={(patch) => updateScenario(selectedIdx, patch)}
-            onDelete={() => deleteScenario(selectedIdx)}
-          />
+          <>
+            <ScenarioMapPreview scenario={selected} />
+            <ScenarioForm
+              scenario={selected}
+              index={selectedIdx}
+              onChange={(patch) => updateScenario(selectedIdx, patch)}
+              onDelete={() => deleteScenario(selectedIdx)}
+            />
+          </>
         ) : (
           <p className="text-sm text-gray-500">No scenarios defined.</p>
         )}


### PR DESCRIPTION
## Summary
- Consolidate admin navigation so settings live on the scenarios page
- Show scenario settings alongside a Leaflet map preview for the selected scenario
- Provide reusable `ScenarioMapPreview` component for route visualization

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0509497688331986cfd0ecb3d8416