### PR TITLE
Add scenario names to configuration and admin dashboard

### DIFF
--- a/client/app/api/route-endpoints/route.js
+++ b/client/app/api/route-endpoints/route.js
@@ -50,8 +50,8 @@ function buildScenarios(cfg) {
       start: pickOne(sc.start),
       end: pickOne(sc.end),
       default_route_time: pickOne(sc.default_route_time),
-      name: pickOne(sc.name),
-      description: pickOne(sc.description),
+      name: Array.isArray(sc.name) ? pickOne(sc.name) : sc.name,
+      description: Array.isArray(sc.description) ? pickOne(sc.description) : sc.description,
       choice_list: (sc.choice_list || []).map((route) => ({
         middle_point: pickOne(route.middle_point),
         tts: pickOne(route.tts),

--- a/client/config/scenariosConfig.json
+++ b/client/config/scenariosConfig.json
@@ -1,94 +1,176 @@
 {
-"scenarios": [
-{
-"start": [
-[45.44133515211266, -75.60859929166942],
-[45.45000000000000, -75.62000000000000]
-],
-"end": [
-[45.298074993041894, -75.93887282992091],
-[45.31000000000000, -75.95000000000000]
-],
-"default_route_time": [1500],
-"choice_list": [
-{
-"middle_point": [
-[45.37434260639422, -75.69853482150437],
-[45.38000000000000, -75.71000000000000]
-],
-"tts": [4, 7, 12],
-"preselected": false
-},
-{
-"middle_point": [
-[45.33042787045188, -75.76378154531083],
-[45.33500000000000, -75.77000000000000]
-],
-"tts": [6, 9, 14],
-"preselected": false
-},
-{
-"middle_point": [
-[45.34537358598173, -75.66420688040428],
-[45.35000000000000, -75.67000000000000]
-],
-"tts": [10, 13, 18],
-"preselected": false
-}
-],
-"name": ["drivers safety", "individual safety"],
-"description": [
-"This route prioritizes safer streets with better lighting and lower traffic.",
-"Safety for the driver: avoid unprotected left-hand turns."
-],
-"randomly_preselect_route": false
-},
-{
-"start": [
-[45.50010000000000, -75.60010000000000],
-[45.50500000000000, -75.61000000000000]
-],
-"end": [
-[45.26050000000000, -75.92050000000000],
-[45.27000000000000, -75.93000000000000]
-],
-"default_route_time": [1320],
-"choice_list": [
-{
-"middle_point": [
-[45.42000000000000, -75.70000000000000],
-[45.42500000000000, -75.70500000000000]
-],
-"tts": [5, 8, 11],
-"preselected": false
-},
-{
-"middle_point": [
-[45.36000000000000, -75.74000000000000],
-[45.36500000000000, -75.74500000000000]
-],
-"tts": [7, 10, 15],
-"preselected": false
-},
-{
-"middle_point": [
-[45.32000000000000, -75.68000000000000],
-[45.32500000000000, -75.68500000000000]
-],
-"tts": [9, 12, 16],
-"preselected": false
-}
-],
-"name": ["time-efficient safety", "infrastructure-prioritized safety"],
-"description": [
-"Optimizes for protected intersections, wider lanes, and signalized crossings while keeping travel times reasonable.",
-"Prefers arterials with medians, dedicated turn phases, and access-controlled segments to reduce conflict points."
-],
-"randomly_preselect_route": false
-}
-],
-"settings": {
-"scenario_shuffle": false,
-"number_of_scenarios": 2
-}
+  "scenarios": [
+    {
+      "start": [
+        [
+          45.44133515211266,
+          -75.60859929166942
+        ],
+        [
+          45.45,
+          -75.62
+        ]
+      ],
+      "end": [
+        [
+          45.298074993041894,
+          -75.93887282992091
+        ],
+        [
+          45.31,
+          -75.95
+        ]
+      ],
+      "default_route_time": [
+        1500
+      ],
+      "choice_list": [
+        {
+          "middle_point": [
+            [
+              45.37434260639422,
+              -75.69853482150437
+            ],
+            [
+              45.38,
+              -75.71
+            ]
+          ],
+          "tts": [
+            4,
+            7,
+            12
+          ],
+          "preselected": false
+        },
+        {
+          "middle_point": [
+            [
+              45.33042787045188,
+              -75.76378154531083
+            ],
+            [
+              45.335,
+              -75.77
+            ]
+          ],
+          "tts": [
+            6,
+            9,
+            14
+          ],
+          "preselected": false
+        },
+        {
+          "middle_point": [
+            [
+              45.34537358598173,
+              -75.66420688040428
+            ],
+            [
+              45.35,
+              -75.67
+            ]
+          ],
+          "tts": [
+            10,
+            13,
+            18
+          ],
+          "preselected": false
+        }
+      ],
+      "name": "drivers safety",
+      "description": "This route prioritizes safer streets with better lighting and lower traffic.",
+      "randomly_preselect_route": false
+    },
+    {
+      "start": [
+        [
+          45.5001,
+          -75.6001
+        ],
+        [
+          45.505,
+          -75.61
+        ]
+      ],
+      "end": [
+        [
+          45.2605,
+          -75.9205
+        ],
+        [
+          45.27,
+          -75.93
+        ]
+      ],
+      "default_route_time": [
+        1320
+      ],
+      "choice_list": [
+        {
+          "middle_point": [
+            [
+              45.42,
+              -75.7
+            ],
+            [
+              45.425,
+              -75.705
+            ]
+          ],
+          "tts": [
+            5,
+            8,
+            11
+          ],
+          "preselected": false
+        },
+        {
+          "middle_point": [
+            [
+              45.36,
+              -75.74
+            ],
+            [
+              45.365,
+              -75.745
+            ]
+          ],
+          "tts": [
+            7,
+            10,
+            15
+          ],
+          "preselected": false
+        },
+        {
+          "middle_point": [
+            [
+              45.32,
+              -75.68
+            ],
+            [
+              45.325,
+              -75.685
+            ]
+          ],
+          "tts": [
+            9,
+            12,
+            16
+          ],
+          "preselected": false
+        }
+      ],
+      "name": "time-efficient safety",
+      "description": "Optimizes for protected intersections, wider lanes, and signalized crossings while keeping travel times reasonable.",
+      "randomly_preselect_route": false
+    }
+  ],
+  "settings": {
+    "scenario_shuffle": false,
+    "number_of_scenarios": 2
+  }
 }

--- a/client/src/admin/ScenariosEditor.jsx
+++ b/client/src/admin/ScenariosEditor.jsx
@@ -112,16 +112,16 @@ function ScenarioForm({ scenario, onChange, onDelete, index }) {
         <label className="block text-sm font-medium mb-1">Name</label>
         <input
           type="text"
-          value={Array.isArray(scenario.name) ? scenario.name[0] : ""}
-          onChange={(e) => onChange({ name: [e.target.value] })}
+          value={scenario.name || ""}
+          onChange={(e) => onChange({ name: e.target.value })}
           className="border rounded px-2 py-1 text-sm w-full"
         />
       </div>
       <div>
         <label className="block text-sm font-medium mb-1">Description</label>
         <textarea
-          value={Array.isArray(scenario.description) ? scenario.description[0] : ""}
-          onChange={(e) => onChange({ description: [e.target.value] })}
+          value={scenario.description || ""}
+          onChange={(e) => onChange({ description: e.target.value })}
           className="border rounded px-2 py-1 text-sm w-full"
         />
       </div>
@@ -184,8 +184,8 @@ export default function ScenariosEditor() {
       end: [[0, 0]],
       default_route_time: [0],
       choice_list: [],
-      name: [""],
-      description: [""],
+      name: "",
+      description: "",
       randomly_preselect_route: false,
     };
     patchScenarios([...scenarios, fresh]);
@@ -219,7 +219,7 @@ export default function ScenariosEditor() {
               onClick={() => setSelectedIdx(i)}
               className={`block w-full text-left px-2 py-1 rounded mb-1 text-sm ${i === selectedIdx ? 'bg-indigo-100' : 'hover:bg-gray-100'}`}
             >
-              {Array.isArray(sc?.name) && sc.name[0] ? sc.name[0] : `Scenario ${i + 1}`}
+              {sc?.name ? sc.name : `Scenario ${i + 1}`}
             </button>
           ))}
         </div>

--- a/client/src/admin/validateScenarios.js
+++ b/client/src/admin/validateScenarios.js
@@ -28,7 +28,7 @@ export function validateScenarioConfig(config) {
 
   const validCoordArray = (arr) => Array.isArray(arr) && arr.length > 0 && arr.every(validCoord);
 
-  const validStrings = (arr) => Array.isArray(arr) && arr.length > 0 && arr.every((s) => typeof s === "string" && s.trim() !== "");
+  const validString = (s) => typeof s === "string" && s.trim() !== "";
 
   scenarios.forEach((sc, i) => {
     const prefix = `Scenario ${i + 1}: `;
@@ -56,11 +56,11 @@ export function validateScenarioConfig(config) {
       errors.push(prefix + "default_route_time must contain positive integers");
     }
 
-    if (!validStrings(sc?.name)) {
-      errors.push(prefix + "name must have at least one string");
+    if (!validString(sc?.name)) {
+      errors.push(prefix + "name must be a non-empty string");
     }
-    if (!validStrings(sc?.description)) {
-      errors.push(prefix + "description must have at least one string");
+    if (!validString(sc?.description)) {
+      errors.push(prefix + "description must be a non-empty string");
     }
 
     if (choiceList.length === 0) {


### PR DESCRIPTION
## Summary
- store each scenario's name directly in `scenariosConfig.json`
- allow admin to edit and display scenario names
- validate that scenarios include non-empty names and descriptions

## Testing
- `cd client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c056bb02fc8331bb36695c9d2c3492