### PR TITLE
Use shared start/end icons in admin map

### DIFF
--- a/client/src/Routing.jsx
+++ b/client/src/Routing.jsx
@@ -2,22 +2,7 @@ import React, { useEffect, useState, useRef } from "react";
 import { useMap, Polyline, Marker } from "react-leaflet";
 import L from "leaflet";
 import "leaflet-routing-machine";
-
-const createTextPinIcon = (color, label) =>
-  L.divIcon({
-    className: "",
-    iconSize: [40, 40],
-    iconAnchor: [20, 40],
-    html: `
-      <svg width="40" height="40" viewBox="0 0 24 24">
-        <path fill="${color}" d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z"/>
-        <text x="12" y="16" text-anchor="middle" font-size="10" font-family="Arial" font-weight="bold" fill="#fff">${label}</text>
-      </svg>
-    `,
-  });
-
-const startIcon = createTextPinIcon("#34A853", "S");
-const endIcon = createTextPinIcon("#EA4335", "E");
+import { startIcon, endIcon } from "./markerIcons";
 
 const Routing = ({
   from,

--- a/client/src/admin/ScenarioMapPreview.jsx
+++ b/client/src/admin/ScenarioMapPreview.jsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from "react";
 import { MapContainer, TileLayer, Marker, Polyline, useMap } from "react-leaflet";
 import L from "leaflet";
 import "leaflet-routing-machine";
+import { startIcon, endIcon } from "../markerIcons";
 
 // Ensure Leaflet marker icons are loaded correctly in bundlers like Next.js
 import markerIcon2x from "leaflet/dist/images/marker-icon-2x.png";
@@ -151,6 +152,7 @@ export default function ScenarioMapPreview({ scenario, onChange = () => {} }) {
           <Marker
             position={start}
             draggable
+            icon={startIcon}
             eventHandlers={{ dragend: handleDrag("start") }}
           />
         )}
@@ -158,6 +160,7 @@ export default function ScenarioMapPreview({ scenario, onChange = () => {} }) {
           <Marker
             position={end}
             draggable
+            icon={endIcon}
             eventHandlers={{ dragend: handleDrag("end") }}
           />
         )}

--- a/client/src/markerIcons.js
+++ b/client/src/markerIcons.js
@@ -1,0 +1,18 @@
+import L from "leaflet";
+
+const createTextPinIcon = (color, label) =>
+  L.divIcon({
+    className: "",
+    iconSize: [40, 40],
+    iconAnchor: [20, 40],
+    html: `
+      <svg width="40" height="40" viewBox="0 0 24 24">
+        <path fill="${color}" d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z"/>
+        <text x="12" y="16" text-anchor="middle" font-size="10" font-family="Arial" font-weight="bold" fill="#fff">${label}</text>
+      </svg>
+    `,
+  });
+
+export const startIcon = createTextPinIcon("#34A853", "S");
+export const endIcon = createTextPinIcon("#EA4335", "E");
+


### PR DESCRIPTION
## Summary
- Add shared `markerIcons` module exporting start and end pin icons
- Use these icons in routing component and admin scenario map preview for consistency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c08d0772788331abedf113211a159a