### PR TITLE
Refactor scenario config to be keyed and rename value field

### DIFF
--- a/client/app/api/log-choice/route.js
+++ b/client/app/api/log-choice/route.js
@@ -40,10 +40,17 @@ export async function POST(req) {
   let totalScenarios = 0;
   try {
     const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-    const scenarios = Array.isArray(config.scenarios) ? config.scenarios.length : 0;
+    const scenariosObj =
+      typeof config.scenarios === 'object' && config.scenarios !== null
+        ? config.scenarios
+        : {};
+    const scenariosCount = Object.keys(scenariosObj).length;
     const settings = config.settings || {};
-    const desired = typeof settings.number_of_scenarios === 'number' ? settings.number_of_scenarios : scenarios;
-    totalScenarios = Math.min(desired, scenarios);
+    const desired =
+      typeof settings.number_of_scenarios === 'number'
+        ? settings.number_of_scenarios
+        : scenariosCount;
+    totalScenarios = Math.min(desired, scenariosCount);
   } catch (err) {
     console.warn('Could not read scenario settings from config. Using fallback.');
   }

--- a/client/app/api/route-endpoints/route.js
+++ b/client/app/api/route-endpoints/route.js
@@ -29,28 +29,32 @@ function pickOne(arr) {
 }
 
 function buildScenarios(cfg) {
-  const allScenarios = Array.isArray(cfg.scenarios) ? cfg.scenarios : [];
+  const allEntries =
+    typeof cfg.scenarios === 'object' && cfg.scenarios !== null
+      ? Object.entries(cfg.scenarios)
+      : [];
   const settings = cfg.settings || {};
   const desired =
     typeof settings.number_of_scenarios === 'number'
       ? settings.number_of_scenarios
-      : allScenarios.length;
-  const count = Math.min(desired, allScenarios.length);
+      : allEntries.length;
+  const count = Math.min(desired, allEntries.length);
 
-  let chosen = allScenarios.slice();
-  if (count < allScenarios.length) {
+  let chosen = allEntries.slice();
+  if (count < allEntries.length) {
     chosen = chosen.sort(() => Math.random() - 0.5).slice(0, count);
   }
   if (settings.scenario_shuffle) {
     chosen = chosen.sort(() => Math.random() - 0.5);
   }
 
-  return chosen.map((sc) => {
+  return chosen.map(([scenarioName, sc]) => {
     const scenario = {
       start: pickOne(sc.start),
       end: pickOne(sc.end),
       default_route_time: pickOne(sc.default_route_time),
-      name: Array.isArray(sc.name) ? pickOne(sc.name) : sc.name,
+      scenario_name: scenarioName,
+      value_name: Array.isArray(sc.value_name) ? pickOne(sc.value_name) : sc.value_name,
       description: Array.isArray(sc.description) ? pickOne(sc.description) : sc.description,
       choice_list: (sc.choice_list || []).map((route) => ({
         middle_point: pickOne(route.middle_point),

--- a/client/config/scenariosConfig.json
+++ b/client/config/scenariosConfig.json
@@ -1,174 +1,86 @@
 {
-  "scenarios": [
-    {
+  "scenarios": {
+    "scenario_1": {
       "start": [
-        [
-          45.44133515211266,
-          -75.60859929166942
-        ],
-        [
-          45.45,
-          -75.62
-        ]
+        [45.44133515211266, -75.60859929166942],
+        [45.45, -75.62]
       ],
       "end": [
-        [
-          45.298074993041894,
-          -75.93887282992091
-        ],
-        [
-          45.31,
-          -75.95
-        ]
+        [45.298074993041894, -75.93887282992091],
+        [45.31, -75.95]
       ],
-      "default_route_time": [
-        1500
-      ],
+      "default_route_time": [1500],
       "choice_list": [
         {
           "middle_point": [
-            [
-              45.37434260639422,
-              -75.69853482150437
-            ],
-            [
-              45.38,
-              -75.71
-            ]
+            [45.37434260639422, -75.69853482150437],
+            [45.38, -75.71]
           ],
-          "tts": [
-            4,
-            7,
-            12
-          ],
+          "tts": [4, 7, 12],
           "preselected": false
         },
         {
           "middle_point": [
-            [
-              45.33042787045188,
-              -75.76378154531083
-            ],
-            [
-              45.335,
-              -75.77
-            ]
+            [45.33042787045188, -75.76378154531083],
+            [45.335, -75.77]
           ],
-          "tts": [
-            6,
-            9,
-            14
-          ],
+          "tts": [6, 9, 14],
           "preselected": false
         },
         {
           "middle_point": [
-            [
-              45.34537358598173,
-              -75.66420688040428
-            ],
-            [
-              45.35,
-              -75.67
-            ]
+            [45.34537358598173, -75.66420688040428],
+            [45.35, -75.67]
           ],
-          "tts": [
-            10,
-            13,
-            18
-          ],
+          "tts": [10, 13, 18],
           "preselected": false
         }
       ],
-      "name": "drivers safety",
+      "value_name": "drivers safety",
       "description": "This route prioritizes safer streets with better lighting and lower traffic.",
       "randomly_preselect_route": false
     },
-    {
+    "scenario_2": {
       "start": [
-        [
-          45.5001,
-          -75.6001
-        ],
-        [
-          45.505,
-          -75.61
-        ]
+        [45.5001, -75.6001],
+        [45.505, -75.61]
       ],
       "end": [
-        [
-          45.2605,
-          -75.9205
-        ],
-        [
-          45.27,
-          -75.93
-        ]
+        [45.2605, -75.9205],
+        [45.27, -75.93]
       ],
-      "default_route_time": [
-        1320
-      ],
+      "default_route_time": [1320],
       "choice_list": [
         {
           "middle_point": [
-            [
-              45.42,
-              -75.7
-            ],
-            [
-              45.425,
-              -75.705
-            ]
+            [45.42, -75.7],
+            [45.425, -75.705]
           ],
-          "tts": [
-            5,
-            8,
-            11
-          ],
+          "tts": [5, 8, 11],
           "preselected": false
         },
         {
           "middle_point": [
-            [
-              45.36,
-              -75.74
-            ],
-            [
-              45.365,
-              -75.745
-            ]
+            [45.36, -75.74],
+            [45.365, -75.745]
           ],
-          "tts": [
-            7,
-            10,
-            15
-          ],
+          "tts": [7, 10, 15],
           "preselected": false
         },
         {
           "middle_point": [
-            [
-              45.32,
-              -75.68
-            ],
-            [
-              45.325,
-              -75.685
-            ]
+            [45.32, -75.68],
+            [45.325, -75.685]
           ],
-          "tts": [
-            9,
-            12,
-            16
-          ],
+          "tts": [9, 12, 16],
           "preselected": false
         }
       ],
-      "name": "time-efficient safety",
+      "value_name": "time-efficient safety",
       "description": "Optimizes for protected intersections, wider lanes, and signalized crossings while keeping travel times reasonable.",
       "randomly_preselect_route": false
     }
-  ],
+  },
   "settings": {
     "scenario_shuffle": false,
     "number_of_scenarios": 2

--- a/client/src/MapRoute.js
+++ b/client/src/MapRoute.js
@@ -40,7 +40,7 @@ const MapRoute = () => {
             const pre = sc.choice_list.find((c) => c.preselected) || sc.choice_list[0];
             const tts = pre?.tts ?? 0;
             return {
-              name: sc.name,
+              label: sc.value_name,
               description: sc.description,
               start: sc.start,
               end: sc.end,
@@ -132,7 +132,7 @@ const MapRoute = () => {
           consentGiven={consentGiven}
           setMapPoints={setMapPoints}
           setRoutes={setRoutes}
-          scenarioLabel={currentScenario.name}
+          scenarioLabel={currentScenario.label}
         />
       </MapContainer>
 
@@ -183,12 +183,12 @@ const MapRoute = () => {
 
       {consentGiven && !showOnboarding && (
         <ScenarioPanel
-          label={currentScenario.name}
+          label={currentScenario.label}
           description={currentScenario.description}
           selectedLabel={selectedLabel}
           onToggle={() =>
             setSelectedLabel(
-              selectedLabel === currentScenario.name ? "default" : currentScenario.name
+              selectedLabel === currentScenario.label ? "default" : currentScenario.label
             )
           }
           onSubmit={() => handleChoice(selectedLabel)}

--- a/client/src/admin/SettingsEditor.jsx
+++ b/client/src/admin/SettingsEditor.jsx
@@ -3,9 +3,12 @@ import { useConfig } from "./AdminApp";
 
 export default function SettingsEditor() {
   const { config, setConfig, setDirty } = useConfig();
-  const scenarios = Array.isArray(config?.scenarios) ? config.scenarios : [];
+  const scenarios =
+    typeof config?.scenarios === "object" && config.scenarios !== null
+      ? config.scenarios
+      : {};
   const settings = config?.settings || {};
-  const max = scenarios.length > 0 ? scenarios.length : 1;
+  const max = Object.keys(scenarios).length > 0 ? Object.keys(scenarios).length : 1;
   const number = settings.number_of_scenarios || 1;
 
   const patch = (patchObj) => {

--- a/client/src/admin/validateScenarios.js
+++ b/client/src/admin/validateScenarios.js
@@ -1,14 +1,22 @@
 export function validateScenarioConfig(config) {
   const errors = [];
-  const scenarios = Array.isArray(config?.scenarios) ? config.scenarios : [];
+  const scenariosObj =
+    typeof config?.scenarios === "object" && config.scenarios !== null
+      ? config.scenarios
+      : {};
+  const scenarioEntries = Object.entries(scenariosObj);
   const settings = config?.settings || {};
 
-  if (!Array.isArray(scenarios) || scenarios.length === 0) {
+  if (scenarioEntries.length === 0) {
     errors.push("At least one scenario must be defined");
   }
 
   const numScenarios = settings.number_of_scenarios;
-  if (!Number.isInteger(numScenarios) || numScenarios < 1 || numScenarios > scenarios.length) {
+  if (
+    !Number.isInteger(numScenarios) ||
+    numScenarios < 1 ||
+    numScenarios > scenarioEntries.length
+  ) {
     errors.push("number_of_scenarios must be between 1 and the number of scenarios");
   }
 
@@ -30,8 +38,8 @@ export function validateScenarioConfig(config) {
 
   const validString = (s) => typeof s === "string" && s.trim() !== "";
 
-  scenarios.forEach((sc, i) => {
-    const prefix = `Scenario ${i + 1}: `;
+  scenarioEntries.forEach(([key, sc], i) => {
+    const prefix = `${key}: `;
     const routes = Array.isArray(sc?.choice_list) ? sc.choice_list : [];
 
     if (!sc.randomly_preselect_route) {
@@ -56,8 +64,8 @@ export function validateScenarioConfig(config) {
       errors.push(prefix + "default_route_time must contain positive integers");
     }
 
-    if (!validString(sc?.name)) {
-      errors.push(prefix + "name must be a non-empty string");
+    if (!validString(sc?.value_name)) {
+      errors.push(prefix + "value_name must be a non-empty string");
     }
     if (!validString(sc?.description)) {
       errors.push(prefix + "description must be a non-empty string");


### PR DESCRIPTION
## Summary
- key scenarios by name in `scenariosConfig.json` and rename each scenario's `name` to `value_name`
- adjust API utilities and logging to read the new keyed scenario format
- update front-end and admin tools to consume `value_name` and scenario keys

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c08e2eab10833198e2881e447bfc8d