### PR TITLE
feat: add scenario name attribute

### DIFF
--- a/client/app/api/route-endpoints/route.js
+++ b/client/app/api/route-endpoints/route.js
@@ -48,12 +48,12 @@ function buildScenarios(cfg) {
     chosen = chosen.sort(() => Math.random() - 0.5);
   }
 
-  return chosen.map(([scenarioName, sc]) => {
+  return chosen.map(([, sc]) => {
     const scenario = {
       start: pickOne(sc.start),
       end: pickOne(sc.end),
       default_route_time: pickOne(sc.default_route_time),
-      scenario_name: scenarioName,
+      scenario_name: Array.isArray(sc.scenario_name) ? pickOne(sc.scenario_name) : sc.scenario_name,
       value_name: Array.isArray(sc.value_name) ? pickOne(sc.value_name) : sc.value_name,
       description: Array.isArray(sc.description) ? pickOne(sc.description) : sc.description,
       choice_list: (sc.choice_list || []).map((route) => ({

--- a/client/config/scenariosConfig.json
+++ b/client/config/scenariosConfig.json
@@ -36,6 +36,7 @@
           "preselected": false
         }
       ],
+      "scenario_name": "Scenario 1",
       "value_name": "drivers safety",
       "description": "This route prioritizes safer streets with better lighting and lower traffic.",
       "randomly_preselect_route": false
@@ -76,6 +77,7 @@
           "preselected": false
         }
       ],
+      "scenario_name": "Scenario 2",
       "value_name": "time-efficient safety",
       "description": "Optimizes for protected intersections, wider lanes, and signalized crossings while keeping travel times reasonable.",
       "randomly_preselect_route": false

--- a/client/src/MapRoute.js
+++ b/client/src/MapRoute.js
@@ -40,7 +40,7 @@ const MapRoute = () => {
             const pre = sc.choice_list.find((c) => c.preselected) || sc.choice_list[0];
             const tts = pre?.tts ?? 0;
             return {
-              label: sc.value_name,
+              label: sc.scenario_name,
               description: sc.description,
               start: sc.start,
               end: sc.end,

--- a/client/src/admin/ScenariosEditor.jsx
+++ b/client/src/admin/ScenariosEditor.jsx
@@ -111,6 +111,15 @@ function ScenarioForm({ scenario, onChange, onDelete, name }) {
         />
       </div>
       <div>
+        <label className="block text-sm font-medium mb-1">Scenario name</label>
+        <input
+          type="text"
+          value={scenario.scenario_name || ""}
+          onChange={(e) => onChange({ scenario_name: e.target.value })}
+          className="border rounded px-2 py-1 text-sm w-full"
+        />
+      </div>
+      <div>
         <label className="block text-sm font-medium mb-1">Value name</label>
         <input
           type="text"
@@ -200,6 +209,7 @@ export default function ScenariosEditor() {
       end: [[0, 0]],
       default_route_time: [0],
       choice_list: [],
+      scenario_name: "",
       value_name: "",
       description: "",
       randomly_preselect_route: false,
@@ -236,7 +246,7 @@ export default function ScenariosEditor() {
               onClick={() => setSelectedKey(key)}
               className={`block w-full text-left px-2 py-1 rounded mb-1 text-sm ${key === selectedKey ? 'bg-indigo-100' : 'hover:bg-gray-100'}`}
             >
-              {scenarios[key]?.value_name ? scenarios[key].value_name : key}
+              {scenarios[key]?.scenario_name ? scenarios[key].scenario_name : key}
             </button>
           ))}
         </div>

--- a/client/src/admin/validateScenarios.js
+++ b/client/src/admin/validateScenarios.js
@@ -64,6 +64,10 @@ export function validateScenarioConfig(config) {
       errors.push(prefix + "default_route_time must contain positive integers");
     }
 
+    if (!validString(sc?.scenario_name)) {
+      errors.push(prefix + "scenario_name must be a non-empty string");
+    }
+
     if (!validString(sc?.value_name)) {
       errors.push(prefix + "value_name must be a non-empty string");
     }


### PR DESCRIPTION
## Summary
- add `scenario_name` field to scenario configs and validation
- show `scenario_name` instead of internal key or value
- propagate `scenario_name` through API and map route display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c097cb81b083318ce7853e594a970a