### PR TITLE
Preselect default route when none chosen

### DIFF
--- a/client/app/api/route-endpoints/route.js
+++ b/client/app/api/route-endpoints/route.js
@@ -79,6 +79,9 @@ function buildScenarios(cfg) {
         }
         return { ...r, preselected: false };
       });
+      if (!found && scenario.choice_list.length > 0) {
+        scenario.choice_list[0].preselected = true;
+      }
     }
 
     delete scenario.randomly_preselect_route;

--- a/client/src/admin/validateScenarios.js
+++ b/client/src/admin/validateScenarios.js
@@ -44,11 +44,10 @@ export function validateScenarioConfig(config) {
 
     if (!sc.randomly_preselect_route) {
       const pre = routes.filter((c) => c.preselected).length;
-      if (pre === 0) {
-        errors.push(prefix + "must have a preselected route or randomly_preselect_route=true");
-      }
       if (pre > 1) {
-        errors.push(prefix + "cannot have multiple preselected routes when randomly_preselect_route=false");
+        errors.push(
+          prefix + "cannot have multiple preselected routes when randomly_preselect_route=false"
+        );
       }
     }
 


### PR DESCRIPTION
## Summary
- Ensure first route is chosen when no alternative is preselected and random preselection is disabled
- Allow scenarios to omit a preselected route unless multiple are marked

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c09e11ab588331bd934b4066d5ac94