### PR TITLE
fix: copy scenario coords precisely

### DIFF
--- a/client/src/admin/ScenariosEditor.jsx
+++ b/client/src/admin/ScenariosEditor.jsx
@@ -202,8 +202,7 @@ export default function ScenariosEditor() {
   };
 
   const addScenario = () => {
-    const lastKey = scenarioKeys[scenarioKeys.length - 1];
-    const prev = lastKey ? scenarios[lastKey] : {};
+    const prev = selectedKey ? scenarios[selectedKey] : {};
     const cloneCoords = (coords) =>
       Array.isArray(coords)
         ? coords.map((p) => (Array.isArray(p) ? [...p] : p))


### PR DESCRIPTION
## Summary
- ensure new scenarios duplicate start/end coordinates from the currently selected scenario

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c09eb3072c83318fe17e651328c47b