### PR TITLE
Optimize route rendering by fetching OSRM coordinates directly

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@opennextjs/cloudflare": "^1.6.5",
         "leaflet": "^1.9.4",
-        "leaflet-routing-machine": "^3.2.12",
         "next": "^15.5.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -8776,23 +8775,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@mapbox/corslite": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@mapbox/corslite/-/corslite-0.0.7.tgz",
-      "integrity": "sha512-w/uS474VFjmqQ7fFWIMZINQM1BAQxDLuoJaZZIPES1BmeYpCtlh9MtbFxKGGDAsfvut8/HircIsVvEYRjQ+iMg==",
-      "license": "BSD"
-    },
-    "node_modules/@mapbox/polyline": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/polyline/-/polyline-0.2.0.tgz",
-      "integrity": "sha512-GCddO0iw6AzOQqZgBmjEQI9Pgo40/yRgkTkikGctE01kNBN0ThWYuAnTD+hRWrAWMV6QJ0rNm4m8DAsaAXE7Pg==",
-      "bin": {
-        "polyline": "bin/polyline.bin.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/@next/env": {
       "version": "15.5.2",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.2.tgz",
@@ -12398,17 +12380,6 @@
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
     },
-    "node_modules/leaflet-routing-machine": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/leaflet-routing-machine/-/leaflet-routing-machine-3.2.12.tgz",
-      "integrity": "sha512-HLde58G1YtD9xSIzZavJ6BPABZaV1hHeGst8ouhzuxmSC3s32NVtADT+njbIUMW1maHRCrsgTk/E4hz5QH7FrA==",
-      "license": "ISC",
-      "dependencies": {
-        "@mapbox/corslite": "0.0.7",
-        "@mapbox/polyline": "^0.2.0",
-        "osrm-text-instructions": "^0.13.2"
-      }
-    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -13311,12 +13282,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/osrm-text-instructions": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/osrm-text-instructions/-/osrm-text-instructions-0.13.4.tgz",
-      "integrity": "sha512-ge4ZTIetMQKAHKq2MwWf83ntzdJN20ndRKRaVNoZ3SkDkBNO99Qddz7r6+hrVx38I+ih6Rk5T1yslczAB6Q9Pg==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@opennextjs/cloudflare": "^1.6.5",
     "leaflet": "^1.9.4",
-    "leaflet-routing-machine": "^3.2.12",
     "next": "^15.5.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/client/src/utils/fetchRoute.js
+++ b/client/src/utils/fetchRoute.js
@@ -1,0 +1,17 @@
+export async function fetchRoute(waypoints, signal) {
+  if (!Array.isArray(waypoints) || waypoints.length < 2) return null;
+  const coordsString = waypoints
+    .map(([lat, lng]) => `${lng},${lat}`)
+    .join(';');
+  const url = `https://router.project-osrm.org/route/v1/driving/${coordsString}?overview=full&geometries=geojson`;
+  try {
+    const res = await fetch(url, { signal });
+    if (!res.ok) return null;
+    const data = await res.json();
+    const coords = data?.routes?.[0]?.geometry?.coordinates;
+    if (!coords) return null;
+    return coords.map(([lng, lat]) => [lat, lng]);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Replace Leaflet Routing Machine with lightweight OSRM fetch utility
- Simplify route drawing in user and admin views for faster rendering
- Drop unused `leaflet-routing-machine` dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0a0d988d08331b16bd38f688e3d44