### PR TITLE
feat: expand admin config pages

### DIFF
--- a/client/app/admin/instructions/page.js
+++ b/client/app/admin/instructions/page.js
@@ -1,0 +1,12 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const AdminApp = dynamic(() => import("../../../src/admin/AdminApp"), {
+  ssr: false,
+});
+
+export default function Page() {
+  return <AdminApp />;
+}
+

--- a/client/app/admin/texts/page.js
+++ b/client/app/admin/texts/page.js
@@ -1,0 +1,12 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const AdminApp = dynamic(() => import("../../../src/admin/AdminApp"), {
+  ssr: false,
+});
+
+export default function Page() {
+  return <AdminApp />;
+}
+

--- a/client/src/admin/AdminApp.jsx
+++ b/client/src/admin/AdminApp.jsx
@@ -5,6 +5,9 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import ScenariosEditor from "./ScenariosEditor";
 import SurveyEditor from "./SurveyEditor";
+import SettingsEditor from "./SettingsEditor";
+import InstructionsEditor from "./InstructionsEditor";
+import TextsEditor from "./TextsEditor";
 import { validateScenarioConfig } from "./validateScenarios";
 
 // ---- Config context
@@ -105,15 +108,18 @@ export default function AdminApp() {
   const router = useRouter();
   const pathname = usePathname();
   const section = pathname.split("/").pop();
+  const validSections = ["scenarios", "settings", "survey", "instructions", "texts"];
 
   useEffect(() => {
-    if (!section || !["scenarios", "survey"].includes(section)) {
+    if (!section || !validSections.includes(section)) {
       router.replace("/admin/scenarios");
     }
   }, [section, router]);
 
   const linkClass = (slug) =>
     `px-2 py-1 rounded ${section === slug ? "bg-white border" : "hover:underline"}`;
+
+  const canSave = ["scenarios", "settings"].includes(section);
 
   const logout = async () => {
     await fetch("/api/admin/logout", {
@@ -130,17 +136,30 @@ export default function AdminApp() {
       <header className="flex items-center justify-between p-4 border-b bg-gray-50">
         <nav className="flex gap-4">
           <Link href="/admin/scenarios" className={linkClass("scenarios")}>Scenarios</Link>
+          <Link href="/admin/settings" className={linkClass("settings")}>Settings</Link>
           <Link href="/admin/survey" className={linkClass("survey")}>Survey</Link>
+          <Link href="/admin/instructions" className={linkClass("instructions")}>Instructions</Link>
+          <Link href="/admin/texts" className={linkClass("texts")}>Texts</Link>
         </nav>
         <div className="flex items-center gap-3">
-          {dirty && <span className="text-xs text-amber-700 bg-amber-100 px-2 py-0.5 rounded">Unsaved changes</span>}
-          {lastSavedAt && !dirty && (
+          {canSave && dirty && (
+            <span className="text-xs text-amber-700 bg-amber-100 px-2 py-0.5 rounded">Unsaved changes</span>
+          )}
+          {canSave && lastSavedAt && !dirty && (
             <span className="text-xs text-gray-500">Last saved: {lastSavedAt.toLocaleString()}</span>
           )}
-          <button onClick={discard} className="border px-3 py-1 rounded">Discard</button>
-          <button onClick={save} disabled={!dirty || saving} className="bg-indigo-600 text-white px-3 py-1 rounded disabled:opacity-50">
-            {saving ? "Saving…" : "Save"}
-          </button>
+          {canSave && (
+            <>
+              <button onClick={discard} className="border px-3 py-1 rounded">Discard</button>
+              <button
+                onClick={save}
+                disabled={!dirty || saving}
+                className="bg-indigo-600 text-white px-3 py-1 rounded disabled:opacity-50"
+              >
+                {saving ? "Saving…" : "Save"}
+              </button>
+            </>
+          )}
           <button onClick={logout} className="border px-3 py-1 rounded">Logout</button>
         </div>
       </header>
@@ -149,7 +168,10 @@ export default function AdminApp() {
       )}
       <main className="p-4">
         {section === "scenarios" && <ScenariosEditor />}
+        {section === "settings" && <SettingsEditor />}
         {section === "survey" && <SurveyEditor />}
+        {section === "instructions" && <InstructionsEditor />}
+        {section === "texts" && <TextsEditor />}
       </main>
     </ConfigContext.Provider>
   );

--- a/client/src/admin/InstructionsEditor.jsx
+++ b/client/src/admin/InstructionsEditor.jsx
@@ -1,0 +1,156 @@
+import React, { useEffect, useState } from "react";
+
+const API_URL = "/api/route-endpoints";
+
+const emptyStep = () => ({ title: "", lines: [""], example: "" });
+
+export default function InstructionsEditor() {
+  const [steps, setSteps] = useState([]);
+  const [selected, setSelected] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(API_URL, { credentials: "include" })
+      .then((r) => {
+        if (!r.ok) throw new Error(`Failed to load config (${r.status})`);
+        return r.json();
+      })
+      .then((data) => {
+        setSteps(Array.isArray(data.instructions) ? data.instructions : []);
+        setError("");
+      })
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleStepChange = (idx, patch) => {
+    setSteps((prev) => prev.map((s, i) => (i === idx ? { ...s, ...patch } : s)));
+  };
+
+  const handleLineChange = (idx, value) => {
+    handleStepChange(idx, { lines: value.split("\n") });
+  };
+
+  const addStep = () => {
+    setSteps((prev) => [...prev, emptyStep()]);
+    setSelected(steps.length);
+  };
+
+  const deleteStep = (idx) => {
+    setSteps((prev) => prev.filter((_, i) => i !== idx));
+    setSelected((s) => (s > idx ? s - 1 : Math.max(0, s - (s === idx ? 1 : 0))));
+  };
+
+  const save = async () => {
+    setSaving(true);
+    setError("");
+    try {
+      const res = await fetch(API_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ instructions: steps }),
+      });
+      if (!res.ok) throw new Error(`Failed to save (${res.status})`);
+    } catch (e) {
+      setError(e.message || String(e));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const discard = () => {
+    setLoading(true);
+    fetch(API_URL, { credentials: "include" })
+      .then((r) => r.json())
+      .then((data) => setSteps(Array.isArray(data.instructions) ? data.instructions : []))
+      .finally(() => setLoading(false));
+  };
+
+  if (loading) return <div className="p-6 text-sm text-gray-600">Loading…</div>;
+
+  return (
+    <div className="flex h-[calc(100vh-2rem)] gap-4">
+      <div className="w-64 shrink-0 border rounded-2xl overflow-hidden flex flex-col">
+        <div className="px-4 py-3 border-b bg-gray-50 flex items-center justify-between">
+          <h2 className="font-semibold">Steps</h2>
+          <button onClick={addStep} className="text-sm px-2 py-1 rounded-lg border">Add</button>
+        </div>
+        <div className="flex-1 overflow-auto">
+          {steps.length === 0 ? (
+            <div className="p-4 text-sm text-gray-500">No steps yet.</div>
+          ) : (
+            <ul className="divide-y">
+              {steps.map((s, i) => (
+                <li
+                  key={i}
+                  className={`px-3 py-2 cursor-pointer ${selected === i ? "bg-indigo-50" : "hover:bg-gray-50"}`}
+                  onClick={() => setSelected(i)}
+                >
+                  <div className="truncate text-sm font-medium">{s.title || `Step ${i + 1}`}</div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+      <div className="flex-1 flex flex-col gap-3">
+        {error && (
+          <div className="border rounded-xl p-3 text-sm bg-red-50 border-red-200 text-red-800">{error}</div>
+        )}
+        {steps[selected] ? (
+          <div className="flex-1 overflow-auto space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">Title</label>
+              <input
+                type="text"
+                value={steps[selected].title}
+                onChange={(e) => handleStepChange(selected, { title: e.target.value })}
+                className="w-full border rounded px-2 py-1 text-sm"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Lines</label>
+              <textarea
+                value={(steps[selected].lines || []).join("\n")}
+                onChange={(e) => handleLineChange(selected, e.target.value)}
+                className="w-full border rounded px-2 py-1 text-sm h-32"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Example (optional)</label>
+              <input
+                type="text"
+                value={steps[selected].example || ""}
+                onChange={(e) => handleStepChange(selected, { example: e.target.value })}
+                className="w-full border rounded px-2 py-1 text-sm"
+              />
+            </div>
+            <button
+              onClick={() => deleteStep(selected)}
+              className="text-sm px-3 py-1 border rounded-lg text-red-600"
+            >
+              Delete step
+            </button>
+          </div>
+        ) : (
+          <div className="text-sm text-gray-500">No step selected.</div>
+        )}
+        <div className="flex justify-end gap-2">
+          <button onClick={discard} className="px-3 py-1.5 border rounded-xl">Discard</button>
+          <button
+            onClick={save}
+            disabled={saving}
+            className="px-3 py-1.5 rounded-xl text-white bg-indigo-600 disabled:opacity-50"
+          >
+            {saving ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/client/src/admin/TextsEditor.jsx
+++ b/client/src/admin/TextsEditor.jsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useState } from "react";
+
+const API_URL = "/api/route-endpoints";
+
+export default function TextsEditor() {
+  const [consentText, setConsentText] = useState("");
+  const [scenarioText, setScenarioText] = useState({ line1: "", line2: "", line3: "" });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(API_URL, { credentials: "include" })
+      .then((r) => {
+        if (!r.ok) throw new Error(`Failed to load config (${r.status})`);
+        return r.json();
+      })
+      .then((data) => {
+        setConsentText(data.consentText || "");
+        setScenarioText(data.scenarioText || { line1: "", line2: "", line3: "" });
+        setError("");
+      })
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const save = async () => {
+    setSaving(true);
+    setError("");
+    try {
+      const res = await fetch(API_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ consentText, scenarioText }),
+      });
+      if (!res.ok) throw new Error(`Failed to save (${res.status})`);
+    } catch (e) {
+      setError(e.message || String(e));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const discard = () => {
+    setLoading(true);
+    fetch(API_URL, { credentials: "include" })
+      .then((r) => r.json())
+      .then((data) => {
+        setConsentText(data.consentText || "");
+        setScenarioText(data.scenarioText || { line1: "", line2: "", line3: "" });
+      })
+      .finally(() => setLoading(false));
+  };
+
+  if (loading) return <div className="p-6 text-sm text-gray-600">Loading…</div>;
+
+  return (
+    <div className="max-w-3xl space-y-6">
+      {error && (
+        <div className="border rounded-xl p-3 text-sm bg-red-50 border-red-200 text-red-800">{error}</div>
+      )}
+      <div>
+        <label className="block text-sm font-medium mb-1">Consent text</label>
+        <textarea
+          value={consentText}
+          onChange={(e) => setConsentText(e.target.value)}
+          className="w-full border rounded px-2 py-1 text-sm h-48"
+        />
+      </div>
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold">Scenario text</h2>
+        <div>
+          <label className="block text-sm font-medium mb-1">Line 1</label>
+          <input
+            type="text"
+            value={scenarioText.line1 || ""}
+            onChange={(e) => setScenarioText((s) => ({ ...s, line1: e.target.value }))}
+            className="w-full border rounded px-2 py-1 text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Line 2</label>
+          <input
+            type="text"
+            value={scenarioText.line2 || ""}
+            onChange={(e) => setScenarioText((s) => ({ ...s, line2: e.target.value }))}
+            className="w-full border rounded px-2 py-1 text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Line 3</label>
+          <input
+            type="text"
+            value={scenarioText.line3 || ""}
+            onChange={(e) => setScenarioText((s) => ({ ...s, line3: e.target.value }))}
+            className="w-full border rounded px-2 py-1 text-sm"
+          />
+        </div>
+      </div>
+      <div className="flex gap-2">
+        <button onClick={discard} className="px-3 py-1.5 border rounded-xl">Discard</button>
+        <button
+          onClick={save}
+          disabled={saving}
+          className="px-3 py-1.5 rounded-xl text-white bg-indigo-600 disabled:opacity-50"
+        >
+          {saving ? "Saving…" : "Save"}
+        </button>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- expand admin app navigation with settings, instructions, and text sections
- add editors for instructions steps and text content
- expose pages for instructions and texts in the admin dashboard

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c0a4b87b308331aa5a00eeb25e5644