### PR TITLE
Ensure scenario editor panel overlays map

### DIFF
--- a/client/src/admin/ScenariosEditor.jsx
+++ b/client/src/admin/ScenariosEditor.jsx
@@ -247,7 +247,7 @@ export default function ScenariosEditor() {
         <ScenarioMapPreview
           scenario={selected}
           onChange={(patch) => updateScenario(selectedKey, patch)}
-          className="absolute inset-0"
+          className="absolute inset-0 z-0"
         />
       )}
       <div className="absolute top-0 left-0 z-10 h-full w-[30rem] max-w-full overflow-y-auto bg-white p-4 space-y-6 shadow-md">


### PR DESCRIPTION
## Summary
- Establish stacking context for the admin scenario map so the editor panel layers above it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0a6fa53f48331810b2cb6a550f3aa