### PR TITLE
Clamp number_of_scenarios to available scenarios

### DIFF
--- a/client/src/admin/SettingsEditor.jsx
+++ b/client/src/admin/SettingsEditor.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useConfig } from "./AdminApp";
 
 export default function SettingsEditor() {
@@ -17,6 +17,12 @@ export default function SettingsEditor() {
   };
 
   const boundedNumber = Math.min(Math.max(number, 1), max);
+
+  useEffect(() => {
+    if (number !== boundedNumber) {
+      patch({ number_of_scenarios: boundedNumber });
+    }
+  }, [number, boundedNumber]);
 
   return (
     <div className="max-w-xl space-y-6">


### PR DESCRIPTION
## Summary
- ensure Settings editor automatically syncs `number_of_scenarios` to the available scenarios count
- prevents validation errors when only one scenario is defined

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0a89921008331b418522fffa0c5ef