### PR TITLE
Use minutes for default route times

### DIFF
--- a/client/config/scenariosConfig.json
+++ b/client/config/scenariosConfig.json
@@ -9,7 +9,7 @@
         [45.298074993041894, -75.93887282992091],
         [45.31, -75.95]
       ],
-      "default_route_time": [1500],
+      "default_route_time": [25],
       "choice_list": [
         {
           "middle_point": [
@@ -50,7 +50,7 @@
         [45.2605, -75.9205],
         [45.27, -75.93]
       ],
-      "default_route_time": [1320],
+      "default_route_time": [22],
       "choice_list": [
         {
           "middle_point": [


### PR DESCRIPTION
## Summary
- Convert scenario default route times from seconds to minutes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0a9cd00e883319181a01c285d9ef8