### PR TITLE
Handle admin scenario config on client

### DIFF
--- a/client/app/api/route-endpoints/route.js
+++ b/client/app/api/route-endpoints/route.js
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import fs from 'fs/promises';
 import path from 'path';
 import { requireAdmin } from '../_utils';
+import { buildScenarios } from "../../../src/utils/buildScenarios";
 
 // Config files live under the `config` directory. The previous implementation
 // attempted to load them from the project root which meant the API responded
@@ -23,71 +24,6 @@ async function readJson(p) {
   }
 }
 
-function pickOne(arr) {
-  if (!Array.isArray(arr) || arr.length === 0) return null;
-  return arr[Math.floor(Math.random() * arr.length)];
-}
-
-function buildScenarios(cfg) {
-  const allEntries =
-    typeof cfg.scenarios === 'object' && cfg.scenarios !== null
-      ? Object.entries(cfg.scenarios)
-      : [];
-  const settings = cfg.settings || {};
-  const desired =
-    typeof settings.number_of_scenarios === 'number'
-      ? settings.number_of_scenarios
-      : allEntries.length;
-  const count = Math.min(desired, allEntries.length);
-
-  let chosen = allEntries.slice();
-  if (count < allEntries.length) {
-    chosen = chosen.sort(() => Math.random() - 0.5).slice(0, count);
-  }
-  if (settings.scenario_shuffle) {
-    chosen = chosen.sort(() => Math.random() - 0.5);
-  }
-
-  return chosen.map(([, sc]) => {
-    const scenario = {
-      start: pickOne(sc.start),
-      end: pickOne(sc.end),
-      default_route_time: pickOne(sc.default_route_time),
-      scenario_name: Array.isArray(sc.scenario_name) ? pickOne(sc.scenario_name) : sc.scenario_name,
-      value_name: Array.isArray(sc.value_name) ? pickOne(sc.value_name) : sc.value_name,
-      description: Array.isArray(sc.description) ? pickOne(sc.description) : sc.description,
-      choice_list: (sc.choice_list || []).map((route) => ({
-        middle_point: pickOne(route.middle_point),
-        tts: pickOne(route.tts),
-        preselected: route.preselected,
-      })),
-      randomly_preselect_route: sc.randomly_preselect_route,
-    };
-
-    if (scenario.randomly_preselect_route) {
-      const idx = Math.floor(Math.random() * scenario.choice_list.length);
-      scenario.choice_list = scenario.choice_list.map((r, i) => ({
-        ...r,
-        preselected: i === idx,
-      }));
-    } else {
-      let found = false;
-      scenario.choice_list = scenario.choice_list.map((r) => {
-        if (r.preselected && !found) {
-          found = true;
-          return r;
-        }
-        return { ...r, preselected: false };
-      });
-      if (!found && scenario.choice_list.length > 0) {
-        scenario.choice_list[0].preselected = true;
-      }
-    }
-
-    delete scenario.randomly_preselect_route;
-    return scenario;
-  });
-}
 
 export async function GET(req) {
   try {

--- a/client/src/MapRoute.js
+++ b/client/src/MapRoute.js
@@ -11,6 +11,7 @@ import ScenarioPanel from "./ScenarioPanel";
 import ProgressBar from "./ProgressBar";
 import { v4 as uuidv4 } from "uuid";
 import { useRouter } from "next/navigation";
+import { buildScenarios } from "./utils/buildScenarios";
 
 const MapRoute = () => {
   const [routeConfig, setRouteConfig] = useState(null);
@@ -35,8 +36,11 @@ const MapRoute = () => {
       .then((res) => res.json())
       .then((data) => {
         setRouteConfig(data);
+        const builtScenarios = Array.isArray(data.scenarios)
+          ? data.scenarios
+          : buildScenarios({ scenarios: data.scenarios, settings: data.settings });
         setScenarios(
-          (data.scenarios || []).map((sc) => {
+          builtScenarios.map((sc) => {
             const pre = sc.choice_list.find((c) => c.preselected) || sc.choice_list[0];
             const tts = pre?.tts ?? 0;
             return {

--- a/client/src/utils/buildScenarios.js
+++ b/client/src/utils/buildScenarios.js
@@ -1,0 +1,71 @@
+export function pickOne(arr) {
+  if (!Array.isArray(arr) || arr.length === 0) return null;
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+export function buildScenarios(cfg = {}) {
+  const allEntries =
+    typeof cfg.scenarios === "object" && cfg.scenarios !== null
+      ? Object.entries(cfg.scenarios)
+      : [];
+  const settings = cfg.settings || {};
+  const desired =
+    typeof settings.number_of_scenarios === "number"
+      ? settings.number_of_scenarios
+      : allEntries.length;
+  const count = Math.min(desired, allEntries.length);
+
+  let chosen = allEntries.slice();
+  if (count < allEntries.length) {
+    chosen = chosen.sort(() => Math.random() - 0.5).slice(0, count);
+  }
+  if (settings.scenario_shuffle) {
+    chosen = chosen.sort(() => Math.random() - 0.5);
+  }
+
+  return chosen.map(([, sc]) => {
+    const scenario = {
+      start: pickOne(sc.start),
+      end: pickOne(sc.end),
+      default_route_time: pickOne(sc.default_route_time),
+      scenario_name: Array.isArray(sc.scenario_name)
+        ? pickOne(sc.scenario_name)
+        : sc.scenario_name,
+      value_name: Array.isArray(sc.value_name)
+        ? pickOne(sc.value_name)
+        : sc.value_name,
+      description: Array.isArray(sc.description)
+        ? pickOne(sc.description)
+        : sc.description,
+      choice_list: (sc.choice_list || []).map((route) => ({
+        middle_point: pickOne(route.middle_point),
+        tts: pickOne(route.tts),
+        preselected: route.preselected,
+      })),
+      randomly_preselect_route: sc.randomly_preselect_route,
+    };
+
+    if (scenario.randomly_preselect_route) {
+      const idx = Math.floor(Math.random() * scenario.choice_list.length);
+      scenario.choice_list = scenario.choice_list.map((r, i) => ({
+        ...r,
+        preselected: i === idx,
+      }));
+    } else {
+      let found = false;
+      scenario.choice_list = scenario.choice_list.map((r) => {
+        if (r.preselected && !found) {
+          found = true;
+          return r;
+        }
+        return { ...r, preselected: false };
+      });
+      if (!found && scenario.choice_list.length > 0) {
+        scenario.choice_list[0].preselected = true;
+      }
+    }
+
+    delete scenario.randomly_preselect_route;
+    return scenario;
+  });
+}


### PR DESCRIPTION
## Summary
- share `buildScenarios` utility between server and client
- generate scenarios on the client when the API returns raw config to admin sessions
- refactor route-endpoints API to use shared scenario builder

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0aa3afc948331a4a0dbe249f66acd