### PR TITLE
Display all alternative routes on root map

### DIFF
--- a/client/src/ScenarioPanel.jsx
+++ b/client/src/ScenarioPanel.jsx
@@ -3,7 +3,7 @@ import React from "react";
 const ScenarioPanel = ({
   label,
   description,
-  selectedLabel,
+  isSelected,
   onToggle,
   onSubmit,
   scenarioNumber,
@@ -12,7 +12,6 @@ const ScenarioPanel = ({
   alternativeTime,
   scenarioText,
 }) => {
-  const isSelected = selectedLabel === label;
 
   const line1 = scenarioText?.line1?.replace('{defaultTime}', defaultTime) ||
     `The time-efficient route takes approximately ${defaultTime} minutes.`;


### PR DESCRIPTION
## Summary
- Render all scenario alternatives by storing full choice list and tracking selected route index
- Update Routing component to fetch and draw every alternative path and highlight the active one
- Adjust ScenarioPanel to reflect selected state without relying on labels

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0ac84ea388331bd4d29ddf1d94ed3