### PR TITLE
Use Cloudflare KV for route config persistence

### DIFF
--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -1,2 +1,5 @@
+/// <reference types="@cloudflare/workers-types" />
+
 interface CloudflareEnv {
+  ROUTE_CONFIG_KV?: KVNamespace;
 }


### PR DESCRIPTION
## Summary
- replace the route endpoint's runtime file reads with static JSON imports so config ships with the worker
- store admin edits in a Cloudflare KV namespace rather than writing to the filesystem and reuse the data for responses
- document the ROUTE_CONFIG_KV binding in the Cloudflare environment declaration

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68caf354016c8331a5087c5307717464