### PR TITLE
Fix admin middleware redirect path

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,10 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-import { getBasePath } from "./src/utils/basePath";
-
-const basePath = getBasePath();
-const loginPath = basePath ? `${basePath}/admin/login` : "/admin/login";
+const loginPath = "/admin/login";
 
 function redirectToLogin(req: NextRequest) {
   const url = req.nextUrl.clone();
@@ -19,7 +16,7 @@ export function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
-  if (pathname === "/admin/login") {
+  if (pathname === loginPath) {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## Summary
- stop adding the base path twice when redirecting unauthenticated admin requests
- centralize the admin login path constant usage in the middleware

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb0b0e4c9c8331b5a2246274c8dcb1