### PR TITLE
Handle filesystem fallback for session logging

### DIFF
--- a/app/api/_fsFallback.js
+++ b/app/api/_fsFallback.js
@@ -1,0 +1,53 @@
+const FALLBACK_FLAG = Symbol.for('moralmap.fsFallback.unavailable');
+
+function getWarningSymbol(context) {
+  const label = context ? String(context) : 'default';
+  return Symbol.for(`moralmap.fsFallback.warned.${label}`);
+}
+
+export function isFileSystemAccessError(error) {
+  if (!error) {
+    return false;
+  }
+
+  const code = error.code;
+  if (code === 'ERR_NOT_SUPPORTED' || code === 'EACCES' || code === 'EPERM') {
+    return true;
+  }
+
+  const message = typeof error.message === 'string' ? error.message.toLowerCase() : '';
+  if (!message) {
+    return false;
+  }
+
+  return (
+    message.includes('not implemented') ||
+    message.includes('not supported') ||
+    message.includes('operation not permitted') ||
+    message.includes('read-only file system') ||
+    message.includes('read only file system') ||
+    message.includes('readonly file system')
+  );
+}
+
+export function markFileSystemUnavailable(error, context) {
+  globalThis[FALLBACK_FLAG] = true;
+
+  const warningSymbol = getWarningSymbol(context);
+  if (globalThis[warningSymbol]) {
+    return;
+  }
+
+  globalThis[warningSymbol] = true;
+
+  const detail = error && error.message ? ` (${error.message})` : '';
+  const prefix = context
+    ? `Falling back to in-memory storage for ${context}`
+    : 'Falling back to in-memory storage';
+
+  console.warn(`${prefix} because the filesystem is not available.${detail}`);
+}
+
+export function isFileSystemUnavailable() {
+  return globalThis[FALLBACK_FLAG] === true;
+}

--- a/app/api/_sessionStore.js
+++ b/app/api/_sessionStore.js
@@ -1,6 +1,11 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import {
+  isFileSystemAccessError,
+  isFileSystemUnavailable,
+  markFileSystemUnavailable,
+} from './_fsFallback.js';
 
 // Resolve the path relative to the project root so all routes reference
 // the same file regardless of their working directory.
@@ -8,16 +13,70 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const sessionsFile = path.join(__dirname, '..', '..', 'sessions.json');
 
+const MEMORY_STORE_KEY = Symbol.for('moralmap.sessions.memory');
+
+function getMemoryStore() {
+  const existing = globalThis[MEMORY_STORE_KEY];
+  if (existing && typeof existing === 'object') {
+    return existing;
+  }
+
+  const initial = {};
+  globalThis[MEMORY_STORE_KEY] = initial;
+  return initial;
+}
+
+function updateMemoryStore(sessions) {
+  if (sessions && typeof sessions === 'object') {
+    globalThis[MEMORY_STORE_KEY] = sessions;
+  } else {
+    globalThis[MEMORY_STORE_KEY] = {};
+  }
+}
 
 export function loadSessions() {
+  if (isFileSystemUnavailable()) {
+    return getMemoryStore();
+  }
+
   try {
     const data = fs.readFileSync(sessionsFile, 'utf8');
-    return JSON.parse(data);
-  } catch {
+    const parsed = JSON.parse(data);
+    updateMemoryStore(parsed);
+    return parsed;
+  } catch (error) {
+    if (isFileSystemAccessError(error)) {
+      markFileSystemUnavailable(error, 'session tracking');
+      return getMemoryStore();
+    }
+
+    if (error && error.code === 'ENOENT') {
+      const empty = {};
+      updateMemoryStore(empty);
+      return empty;
+    }
+
+    updateMemoryStore({});
     return {};
   }
 }
 
 export function saveSessions(sessions) {
-  fs.writeFileSync(sessionsFile, JSON.stringify(sessions), 'utf8');
+  if (isFileSystemUnavailable()) {
+    updateMemoryStore(sessions);
+    return;
+  }
+
+  try {
+    fs.writeFileSync(sessionsFile, JSON.stringify(sessions), 'utf8');
+    updateMemoryStore(sessions);
+  } catch (error) {
+    if (isFileSystemAccessError(error)) {
+      markFileSystemUnavailable(error, 'session tracking');
+      updateMemoryStore(sessions);
+      return;
+    }
+
+    throw error;
+  }
 }

--- a/app/api/log-survey/route.js
+++ b/app/api/log-survey/route.js
@@ -3,12 +3,27 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { loadSessions, saveSessions } from '../_sessionStore.js';
+import {
+  isFileSystemAccessError,
+  isFileSystemUnavailable,
+  markFileSystemUnavailable,
+} from '../_fsFallback.js';
 
 
 // Ensure we write to a stable path regardless of runtime cwd
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const dataPath = path.join(__dirname, '..', '..', '..', 'user_data.jsonl');
+
+const USER_DATA_MEMORY_KEY = Symbol.for('moralmap.userDataLog.memory');
+
+function appendToMemoryLog(entry) {
+  if (Array.isArray(globalThis[USER_DATA_MEMORY_KEY])) {
+    globalThis[USER_DATA_MEMORY_KEY].push(entry);
+  } else {
+    globalThis[USER_DATA_MEMORY_KEY] = [entry];
+  }
+}
 
 export async function POST(req) {
   const { sessionId, responses } = await req.json();
@@ -25,8 +40,28 @@ export async function POST(req) {
 
   session.responses = responses;
 
+  const logEntry =
+    typeof structuredClone === 'function'
+      ? structuredClone(session)
+      : JSON.parse(JSON.stringify(session));
+  const serializedEntry = `${JSON.stringify(logEntry)}\n`;
+
   try {
-    fs.appendFileSync(dataPath, JSON.stringify(session) + '\n', 'utf8');
+    if (isFileSystemUnavailable()) {
+      appendToMemoryLog(logEntry);
+    } else {
+      try {
+        fs.appendFileSync(dataPath, serializedEntry, 'utf8');
+      } catch (err) {
+        if (isFileSystemAccessError(err)) {
+          markFileSystemUnavailable(err, 'user data logging');
+          appendToMemoryLog(logEntry);
+        } else {
+          throw err;
+        }
+      }
+    }
+
     delete sessions[sessionId];
     saveSessions(sessions);
     return NextResponse.json({ success: true });


### PR DESCRIPTION
## Summary
- add a small helper to detect when the filesystem is unavailable and warn once
- fall back to an in-memory session store when file reads or writes fail
- mirror the fallback when storing survey results so submissions succeed without disk access

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb0ac727f483319cb6610c68f6c481