### PR TITLE
feat: back config and user data with webflow kv

### DIFF
--- a/app/api/_configStore.js
+++ b/app/api/_configStore.js
@@ -1,0 +1,69 @@
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+import scenariosDefaults from '../../config/scenariosConfig.json' assert { type: 'json' };
+import textsDefaults from '../../config/textsConfig.json' assert { type: 'json' };
+import instructionsDefaults from '../../config/instructionsConfig.json' assert { type: 'json' };
+import surveyDefaults from '../../config/surveyConfig.json' assert { type: 'json' };
+
+export const CONFIG_KV_KEY = 'route-config';
+
+export function ensureObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+export function getConfigKv() {
+  try {
+    const { env } = getCloudflareContext();
+    return env?.ROUTE_CONFIG_KV;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function readPersistedConfig(kv = getConfigKv()) {
+  if (!kv) return {};
+  try {
+    const stored = await kv.get(CONFIG_KV_KEY, { type: 'json' });
+    if (stored && typeof stored === 'object' && !Array.isArray(stored)) {
+      return stored;
+    }
+    return {};
+  } catch (err) {
+    console.error('Failed to read route config from KV:', err);
+    return {};
+  }
+}
+
+export function mergeWithDefaults(persisted = {}) {
+  const scenariosConfig = ensureObject(persisted.scenariosConfig);
+  const textsConfig = ensureObject(persisted.textsConfig);
+  const instructionsConfig = ensureObject(persisted.instructionsConfig);
+  const surveyConfig = ensureObject(persisted.surveyConfig);
+
+  return {
+    scenarioCfg: { ...scenariosDefaults, ...scenariosConfig },
+    textsCfg: { ...textsDefaults, ...textsConfig },
+    instructionsCfg: { ...instructionsDefaults, ...instructionsConfig },
+    surveyCfg: { ...surveyDefaults, ...surveyConfig },
+  };
+}
+
+export async function persistConfig(mutator) {
+  const kv = getConfigKv();
+  if (!kv) {
+    throw new Error('ROUTE_CONFIG_KV binding is not configured');
+  }
+
+  const current = await readPersistedConfig(kv);
+  const nextState = mutator({ ...current });
+  if (!nextState || typeof nextState !== 'object' || Array.isArray(nextState)) {
+    throw new Error('Invalid config object produced by mutator');
+  }
+
+  await kv.put(CONFIG_KV_KEY, JSON.stringify(nextState));
+  return nextState;
+}
+
+export async function loadMergedConfig() {
+  const persisted = await readPersistedConfig(getConfigKv());
+  return mergeWithDefaults(persisted);
+}

--- a/app/api/route-endpoints/route.js
+++ b/app/api/route-endpoints/route.js
@@ -1,71 +1,13 @@
 import { NextResponse } from 'next/server';
-import { getCloudflareContext } from '@opennextjs/cloudflare';
-import scenariosDefaults from '../../../config/scenariosConfig.json' assert { type: 'json' };
-import textsDefaults from '../../../config/textsConfig.json' assert { type: 'json' };
-import instructionsDefaults from '../../../config/instructionsConfig.json' assert { type: 'json' };
-import surveyDefaults from '../../../config/surveyConfig.json' assert { type: 'json' };
 import { requireAdmin } from '../_utils';
 import { buildScenarios } from '../../../src/utils/buildScenarios';
-
-const CONFIG_KV_KEY = 'route-config';
-
-function ensureObject(value) {
-  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
-}
-
-function getConfigKv() {
-  try {
-    const { env } = getCloudflareContext();
-    return env?.ROUTE_CONFIG_KV;
-  } catch {
-    return undefined;
-  }
-}
-
-async function readPersistedConfig(kv) {
-  if (!kv) return {};
-  try {
-    const stored = await kv.get(CONFIG_KV_KEY, { type: 'json' });
-    if (stored && typeof stored === 'object' && !Array.isArray(stored)) {
-      return stored;
-    }
-    return {};
-  } catch (err) {
-    console.error('Failed to read route config from KV:', err);
-    return {};
-  }
-}
-
-function mergeWithDefaults(persisted = {}) {
-  const scenariosConfig = ensureObject(persisted.scenariosConfig);
-  const textsConfig = ensureObject(persisted.textsConfig);
-  const instructionsConfig = ensureObject(persisted.instructionsConfig);
-  const surveyConfig = ensureObject(persisted.surveyConfig);
-
-  return {
-    scenarioCfg: { ...scenariosDefaults, ...scenariosConfig },
-    textsCfg: { ...textsDefaults, ...textsConfig },
-    instructionsCfg: { ...instructionsDefaults, ...instructionsConfig },
-    surveyCfg: { ...surveyDefaults, ...surveyConfig },
-  };
-}
-
-async function persistConfig(mutator) {
-  const kv = getConfigKv();
-  if (!kv) {
-    throw new Error('ROUTE_CONFIG_KV binding is not configured');
-  }
-
-  const current = await readPersistedConfig(kv);
-  const nextState = mutator({ ...current });
-  if (!nextState || typeof nextState !== 'object' || Array.isArray(nextState)) {
-    throw new Error('Invalid config object produced by mutator');
-  }
-
-  await kv.put(CONFIG_KV_KEY, JSON.stringify(nextState));
-  return nextState;
-}
-
+import {
+  ensureObject,
+  getConfigKv,
+  mergeWithDefaults,
+  persistConfig,
+  readPersistedConfig,
+} from '../_configStore.js';
 
 export async function GET(req) {
   try {

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -2,4 +2,6 @@
 
 interface CloudflareEnv {
   ROUTE_CONFIG_KV?: KVNamespace;
+  SESSION_DATA_KV?: KVNamespace;
+  USER_DATA_KV?: KVNamespace;
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,6 +6,11 @@
     "compatibility_flags": [
         "nodejs_compat"
     ],
+    "kv_namespaces": [
+        { "binding": "ROUTE_CONFIG_KV" },
+        { "binding": "SESSION_DATA_KV" },
+        { "binding": "USER_DATA_KV" }
+    ],
     "assets": {
         "binding": "ASSETS",
         "directory": ".open-next/assets"


### PR DESCRIPTION
## Summary
- add a shared config store that persists experiment settings in the ROUTE_CONFIG_KV namespace
- replace the file-based session store with a KV-backed implementation and update the log-choice route to use it
- log survey submissions to USER_DATA_KV while keeping filesystem fallbacks, and declare the new bindings in wrangler.jsonc and cloudflare-env.d.ts

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cefb46fcfc83318577922f8d035f02