### PR TITLE
Configure Cloudflare worker bindings

### DIFF
--- a/open-next.config.ts
+++ b/open-next.config.ts
@@ -1,7 +1,27 @@
 import type { NextConfig } from "next";
-
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 
-export default defineCloudflareConfig({
-});
+const baseConfig = defineCloudflareConfig();
 
+const config: NextConfig = {
+  ...baseConfig,
+  workers: {
+    default: {
+      bindings: {
+        kvNamespaces: [
+          { binding: "ROUTE_CONFIG_KV", id: "1234567893" },
+          { binding: "SESSION_DATA_KV", id: "1234567890" },
+          { binding: "USER_DATA_KV", id: "1234567891" },
+        ],
+        assets: [
+          {
+            binding: "ASSETS",
+            directory: ".open-next/assets",
+          },
+        ],
+      },
+    },
+  },
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- update the OpenNext Cloudflare config to expose the ROUTE_CONFIG_KV, SESSION_DATA_KV, USER_DATA_KV, and ASSETS bindings on the default worker

## Testing
- CI=1 npx opennextjs-cloudflare build
- npx wrangler deploy --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68d06ec469cc8331b6cf7c29c54b0fe1