### PR TITLE
Fix admin scenarios data loading

### DIFF
--- a/app/api/route-endpoints/route.js
+++ b/app/api/route-endpoints/route.js
@@ -15,19 +15,24 @@ export async function GET() {
       get('surveyConfig'),
     ]);
 
-    // Build scenarios for the public payload
-    const scenarios = buildScenarios({
-      settings: scenariosConfig?.settings ?? {},
-      scenarios: scenariosConfig?.scenarios ?? {},
+    const rawScenarios = scenariosConfig?.scenarios ?? {};
+    const settings = scenariosConfig?.settings ?? {};
+
+    // Build scenarios for the public payload while returning the full admin config
+    const publicScenarios = buildScenarios({
+      settings,
+      scenarios: rawScenarios,
     });
 
-    // Return the same public shape your UI expects
+    // Return both the admin configuration and the public payload shape
     return NextResponse.json({
-      scenarios,
+      scenarios: rawScenarios,
+      settings,
       consentText: textsConfig?.consentText ?? '',
       scenarioText: textsConfig?.scenarioText ?? {},
       instructions: Array.isArray(instructionsConfig?.steps) ? instructionsConfig.steps : [],
       survey: Array.isArray(surveyConfig?.survey) ? surveyConfig.survey : [],
+      publicScenarios,
     });
   } catch (err) {
     console.error('Failed to load config', err);


### PR DESCRIPTION
## Summary
- update the route-endpoints GET handler to return the raw scenarios and settings configuration alongside the derived public scenarios payload
- expose both admin-facing config fields and the existing public data so the admin UI can render complete scenario forms

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d543dff1608331b3aba3ce4fae0527