### PR TITLE
Enable admin config updates via Edge Config API

### DIFF
--- a/app/api/route-endpoints/route.js
+++ b/app/api/route-endpoints/route.js
@@ -3,7 +3,71 @@ import { NextResponse } from 'next/server';
 import { get } from '@vercel/edge-config';
 import { buildScenarios } from '../../../src/utils/buildScenarios';
 
-export const runtime = 'edge';
+const EDGE_CONFIG_API_BASE = 'https://api.vercel.com/v1/edge-config';
+
+export const runtime = 'nodejs';
+
+const clone = (value) => {
+  if (value === undefined || value === null) return value;
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+};
+
+const parseEdgeConfigConnection = (connectionString) => {
+  if (!connectionString) return null;
+  try {
+    const url = new URL(connectionString);
+    const edgeConfigId = url.pathname.replace(/^\//, '');
+    const token = url.searchParams.get('token');
+    if (!edgeConfigId || !token) return null;
+    return { edgeConfigId, token };
+  } catch {
+    return null;
+  }
+};
+
+const getAdminCredentials = () => {
+  let edgeConfigId = process.env.EDGE_CONFIG_ID || '';
+  let token =
+    process.env.EDGE_CONFIG_ADMIN_TOKEN ||
+    process.env.EDGE_CONFIG_TOKEN ||
+    '';
+
+  if ((!edgeConfigId || !token) && process.env.EDGE_CONFIG) {
+    const parsed = parseEdgeConfigConnection(process.env.EDGE_CONFIG);
+    if (parsed) {
+      edgeConfigId = edgeConfigId || parsed.edgeConfigId;
+      token = token || parsed.token;
+    }
+  }
+
+  if (!edgeConfigId || !token) {
+    throw new Error('Missing Edge Config admin credentials');
+  }
+
+  return { edgeConfigId, token };
+};
+
+const updateEdgeConfigItems = async (items) => {
+  if (!items.length) return;
+  const { edgeConfigId, token } = getAdminCredentials();
+
+  const res = await fetch(`${EDGE_CONFIG_API_BASE}/${edgeConfigId}/items`, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ items }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Edge Config update failed (${res.status}): ${text}`);
+  }
+};
 
 export async function GET() {
   try {
@@ -37,5 +101,120 @@ export async function GET() {
   } catch (err) {
     console.error('Failed to load config', err);
     return NextResponse.json({ error: 'Failed to load config' }, { status: 500 });
+  }
+}
+
+export async function PATCH(req) {
+  let body;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const allowedKeys = ['start', 'end', 'scenarios', 'settings'];
+  const hasUpdates = allowedKeys.some((key) => key in body);
+
+  if (!hasUpdates) {
+    return NextResponse.json({ error: 'No valid fields provided' }, { status: 400 });
+  }
+
+  try {
+    const existing = clone((await get('scenariosConfig')) || {});
+    const updated = existing && typeof existing === 'object' ? existing : {};
+
+    for (const key of allowedKeys) {
+      if (key in body) {
+        updated[key] = body[key];
+      }
+    }
+
+    await updateEdgeConfigItems([
+      {
+        operation: 'upsert',
+        key: 'scenariosConfig',
+        value: updated,
+      },
+    ]);
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error('Failed to save scenarios config', err);
+    return NextResponse.json({ error: 'Failed to save config' }, { status: 500 });
+  }
+}
+
+export async function POST(req) {
+  let body;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const updates = [];
+
+  if ('instructions' in body) {
+    if (!Array.isArray(body.instructions)) {
+      return NextResponse.json({ error: 'instructions must be an array' }, { status: 400 });
+    }
+    updates.push({
+      operation: 'upsert',
+      key: 'instructionsConfig',
+      value: { steps: body.instructions },
+    });
+  }
+
+  if ('consentText' in body || 'scenarioText' in body) {
+    if ('consentText' in body && typeof body.consentText !== 'string') {
+      return NextResponse.json({ error: 'consentText must be a string' }, { status: 400 });
+    }
+    if ('scenarioText' in body && (typeof body.scenarioText !== 'object' || body.scenarioText === null)) {
+      return NextResponse.json({ error: 'scenarioText must be an object' }, { status: 400 });
+    }
+
+    const existingTexts = clone((await get('textsConfig')) || {});
+    const nextTexts = existingTexts && typeof existingTexts === 'object' ? existingTexts : {};
+
+    if ('consentText' in body) {
+      nextTexts.consentText = body.consentText;
+    }
+    if ('scenarioText' in body) {
+      nextTexts.scenarioText = body.scenarioText;
+    }
+
+    updates.push({
+      operation: 'upsert',
+      key: 'textsConfig',
+      value: nextTexts,
+    });
+  }
+
+  if ('survey' in body) {
+    if (!Array.isArray(body.survey)) {
+      return NextResponse.json({ error: 'survey must be an array' }, { status: 400 });
+    }
+
+    const existingSurvey = clone((await get('surveyConfig')) || {});
+    const nextSurvey = existingSurvey && typeof existingSurvey === 'object' ? existingSurvey : {};
+    nextSurvey.survey = body.survey;
+
+    updates.push({
+      operation: 'upsert',
+      key: 'surveyConfig',
+      value: nextSurvey,
+    });
+  }
+
+  if (!updates.length) {
+    return NextResponse.json({ error: 'No valid fields provided' }, { status: 400 });
+  }
+
+  try {
+    await updateEdgeConfigItems(updates);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error('Failed to update config', err);
+    return NextResponse.json({ error: 'Failed to update config' }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- switch the route endpoints API to the Node.js runtime and add helpers for cloning config data and parsing Edge Config credentials
- add PATCH handling for scenario updates and POST handling for instructions, survey, and text updates via the Vercel Edge Config API
- reuse the Edge Config connection string or explicit admin credentials to authorize writes and surface useful errors back to the admin UI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5464066c88331951afba39a02c8ec