### PR TITLE
Use Vercel API token for Edge Config updates

### DIFF
--- a/app/api/route-endpoints/route.js
+++ b/app/api/route-endpoints/route.js
@@ -31,6 +31,8 @@ const parseEdgeConfigConnection = (connectionString) => {
 const getAdminCredentials = () => {
   let edgeConfigId = process.env.EDGE_CONFIG_ID || '';
   let token =
+    process.env.VERCEL_API_TOKEN ||
+    process.env.VERCEL_OIDC_TOKEN ||
     process.env.EDGE_CONFIG_ADMIN_TOKEN ||
     process.env.EDGE_CONFIG_TOKEN ||
     '';
@@ -59,6 +61,9 @@ const updateEdgeConfigItems = async (items) => {
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
+      ...(process.env.EDGE_CONFIG_DIGEST
+        ? { 'X-Vercel-Edge-Config-Digest': process.env.EDGE_CONFIG_DIGEST }
+        : {}),
     },
     body: JSON.stringify({ items }),
   });


### PR DESCRIPTION
## Summary
- prefer the Vercel API or OIDC tokens when building Edge Config admin credentials
- send the optional X-Vercel-Edge-Config-Digest header when an EDGE_CONFIG_DIGEST env var is provided

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d55be592588331842a576640a5edcd