### PR TITLE
Add validation messages to scenario map preview

### DIFF
--- a/src/admin/ScenarioMapPreview.jsx
+++ b/src/admin/ScenarioMapPreview.jsx
@@ -188,9 +188,45 @@ export default function ScenarioMapPreview({
   const [previewMode, setPreviewMode] = useState("canonical");
   const [comboIndex, setComboIndex] = useState(0);
 
-  const start = Array.isArray(scenario?.start?.[0]) ? scenario.start[0] : null;
-  const end = Array.isArray(scenario?.end?.[0]) ? scenario.end[0] : null;
-  if (!start || !end) return null;
+  const startRaw = Array.isArray(scenario?.start) ? scenario.start : [];
+  const endRaw = Array.isArray(scenario?.end) ? scenario.end : [];
+
+  const startOptions = startRaw.filter(isValidCoord);
+  const endOptions = endRaw.filter(isValidCoord);
+
+  const validationErrors = [];
+
+  if (!startRaw.length) {
+    validationErrors.push("Missing starting points");
+  } else if (!startOptions.length) {
+    validationErrors.push("Starting points must be [lat, lng] numbers");
+  }
+
+  if (!endRaw.length) {
+    validationErrors.push("Missing ending points");
+  } else if (!endOptions.length) {
+    validationErrors.push("Ending points must be [lat, lng] numbers");
+  }
+
+  const start = startOptions[0] || null;
+  const end = endOptions[0] || null;
+
+  if (!start || !end) {
+    return (
+      <div
+        className={`relative ${className} flex items-center justify-center rounded border border-dashed border-rose-300 bg-rose-50 p-4 text-sm text-rose-700`}
+      >
+        <div className="space-y-1 text-center">
+          <p className="font-semibold">Unable to render map preview</p>
+          <ul className="space-y-0.5">
+            {validationErrors.map((err) => (
+              <li key={err}>{err}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    );
+  }
 
   const alternatives = Array.isArray(scenario.choice_list) ? scenario.choice_list : [];
 


### PR DESCRIPTION
## Summary
- validate start and end coordinate arrays before rendering the scenario map preview
- show clear UI messages when starting or ending points are missing or invalid

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d5667c6dc88331bac2690fd734dec6