### PR TITLE
Support per-route value metadata in scenarios

### DIFF
--- a/config/scenariosConfig.json
+++ b/config/scenariosConfig.json
@@ -30,17 +30,43 @@
             [
               45.37434260639422,
               -75.69853482150437
+            ],
+            [
+              45.37434260639422,
+              -75.69853482150437
             ]
           ],
           "tts": [
             4
           ],
+          "value_name": [
+            "drivers safety"
+          ],
+          "description": [
+            "This route prioritizes safer streets with better lighting and lower traffic."
+          ],
+          "preselected": false
+        },
+        {
+          "middle_point": [
+            [
+              45.33042787045188,
+              -75.76378154531083
+            ]
+          ],
+          "tts": [
+            6
+          ],
+          "value_name": [
+            "time efficient"
+          ],
+          "description": [
+            "This route balances travel time with exposure to busier arterial roads."
+          ],
           "preselected": false
         }
       ],
-      "scenario_name": "Driver Safety",
-      "value_name": "drivers safety",
-      "description": "This route prioritizes driver safety including avoiding unprotected left turns when possible.",
+      "scenario_name": "Scenario 1",
       "randomly_preselect_route": false
     },
     "scenario_2": {
@@ -82,16 +108,21 @@
           "tts": [
             11
           ],
+          "value_name": [
+            "protected cycling"
+          ],
+          "description": [
+            "This route uses protected cycling infrastructure and minimizes high-traffic intersections."
+          ],
           "preselected": false
         }
       ],
-      "scenario_name": "Vulnerable Road User Safety",
-      "value_name": "time-efficient safety",
-      "description": "This route prioritizes routes that have protected bike lanes and avoids areas with high pedestrian traffic.",
+      "scenario_name": "Scenario 2",
       "randomly_preselect_route": false
+    }
   },
   "settings": {
     "scenario_shuffle": false,
     "number_of_scenarios": 2
   }
-}}
+}

--- a/src/admin/ScenariosEditor.jsx
+++ b/src/admin/ScenariosEditor.jsx
@@ -96,6 +96,51 @@ function NumberListInput({ label, values = [], onChange }) {
   );
 }
 
+function TextListInput({ label, values = [], onChange, placeholder = "" }) {
+  const items = Array.isArray(values)
+    ? values
+    : typeof values === "string"
+    ? [values]
+    : [];
+
+  const update = (idx, val) => {
+    const next = items.map((n, i) => (i === idx ? val : n));
+    onChange(next);
+  };
+
+  const add = () => onChange([...items, ""]);
+  const remove = (idx) => onChange(items.filter((_, i) => i !== idx));
+
+  return (
+    <div className="mb-3">
+      <label className="block text-sm font-medium mb-1">{label}</label>
+      {items.map((text, i) => (
+        <div key={i} className="flex items-center gap-2 mb-1">
+          <input
+            type="text"
+            value={text}
+            placeholder={placeholder}
+            onChange={(e) => update(i, e.target.value)}
+            className="border rounded px-2 py-1 text-sm w-full"
+          />
+          {items.length > 1 && (
+            <button
+              onClick={() => remove(i)}
+              className="text-xs text-red-600"
+              aria-label="Remove value"
+            >
+              ✕
+            </button>
+          )}
+        </div>
+      ))}
+      <button onClick={add} className="text-xs px-2 py-1 border rounded">
+        Add
+      </button>
+    </div>
+  );
+}
+
 function AlternativeRouteEditor({ route, onChange, onDelete, index }) {
   return (
     <div className="border rounded p-3 mb-3">
@@ -114,6 +159,18 @@ function AlternativeRouteEditor({ route, onChange, onDelete, index }) {
         label="TTS"
         values={route.tts}
         onChange={(val) => onChange({ tts: val })}
+      />
+      <TextListInput
+        label="Value names (pool)"
+        values={route.value_name}
+        onChange={(val) => onChange({ value_name: val })}
+        placeholder="e.g. drivers safety"
+      />
+      <TextListInput
+        label="Descriptions (pool)"
+        values={route.description}
+        onChange={(val) => onChange({ description: val })}
+        placeholder="Brief explanation for participants"
       />
       <div className="flex items-center gap-2">
         <input
@@ -148,23 +205,6 @@ function ScenarioForm({ scenario, onChange, name }) {
         values={scenario.default_route_time}
         onChange={(val) => onChange({ default_route_time: val })}
       />
-      <div>
-        <label className="block text-sm font-medium mb-1">Value name</label>
-        <input
-          type="text"
-          value={scenario.value_name || ""}
-          onChange={(e) => onChange({ value_name: e.target.value })}
-          className="border rounded px-2 py-1 text-sm w-full"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium mb-1">Description</label>
-        <textarea
-          value={scenario.description || ""}
-          onChange={(e) => onChange({ description: e.target.value })}
-          className="border rounded px-2 py-1 text-sm w-full"
-        />
-      </div>
       <div className="flex items-center gap-2">
         <input
           type="checkbox"
@@ -188,7 +228,13 @@ function ScenarioForm({ scenario, onChange, name }) {
               onChange({
                 choice_list: [
                   ...(scenario.choice_list || []),
-                  { middle_point: [mid], tts: [0], preselected: false },
+                  {
+                    middle_point: [mid],
+                    tts: [0],
+                    value_name: [""],
+                    description: [""],
+                    preselected: false,
+                  },
                 ],
               });
             }}
@@ -258,8 +304,6 @@ export default function ScenariosEditor() {
           default_route_time: [0],
           choice_list: [],
           scenario_name: `Scenario ${nextIndex}`,
-          value_name: "",
-          description: "",
           randomly_preselect_route: false,
         };
 

--- a/src/admin/validateScenarios.js
+++ b/src/admin/validateScenarios.js
@@ -67,13 +67,6 @@ export function validateScenarioConfig(config) {
       errors.push(prefix + "scenario_name must be a non-empty string");
     }
 
-    if (!validString(sc?.value_name)) {
-      errors.push(prefix + "value_name must be a non-empty string");
-    }
-    if (!validString(sc?.description)) {
-      errors.push(prefix + "description must be a non-empty string");
-    }
-
     if (routes.length === 0) {
       errors.push(prefix + "Alternative routes must not be empty");
     }
@@ -86,6 +79,14 @@ export function validateScenarioConfig(config) {
       const tts = Array.isArray(ch?.tts) ? ch.tts : [];
       if (tts.length === 0 || tts.some((n) => !Number.isInteger(n) || n < 0)) {
         errors.push(cPrefix + "tts must contain non-negative integers");
+      }
+      const valueNames = Array.isArray(ch?.value_name) ? ch.value_name : [];
+      if (valueNames.length === 0 || valueNames.some((s) => !validString(s))) {
+        errors.push(cPrefix + "value_name must be a non-empty array of strings");
+      }
+      const descriptions = Array.isArray(ch?.description) ? ch.description : [];
+      if (descriptions.length === 0 || descriptions.some((s) => !validString(s))) {
+        errors.push(cPrefix + "description must be a non-empty array of strings");
       }
       if (typeof ch?.preselected !== "boolean") {
         errors.push(cPrefix + "preselected must be boolean");

--- a/src/utils/buildScenarios.js
+++ b/src/utils/buildScenarios.js
@@ -41,15 +41,15 @@ export function buildScenarios(cfg = {}) {
       scenario_name: Array.isArray(sc.scenario_name)
         ? pickOne(sc.scenario_name)
         : sc.scenario_name,
-      value_name: Array.isArray(sc.value_name)
-        ? pickOne(sc.value_name)
-        : sc.value_name,
-      description: Array.isArray(sc.description)
-        ? pickOne(sc.description)
-        : sc.description,
       choice_list: (sc.choice_list || []).map((route) => ({
         middle_point: pickOne(route.middle_point),
         tts: pickOne(route.tts),
+        value_name: Array.isArray(route.value_name)
+          ? pickOne(route.value_name)
+          : route.value_name,
+        description: Array.isArray(route.description)
+          ? pickOne(route.description)
+          : route.description,
         preselected: route.preselected,
       })),
       randomly_preselect_route: sc.randomly_preselect_route,


### PR DESCRIPTION
## Summary
- move value name and description pools onto each scenario choice and refresh the sample config
- pick random value/description strings per route during scenario builds and surface them in the map UI
- update the admin scenario editor and validator to manage per-route metadata instead of scenario-level fields

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d56779dd488331b32db4ef1bbcd70f