### PR TITLE
Add per-route toggles for scenario choices

### DIFF
--- a/src/MapRoute.js
+++ b/src/MapRoute.js
@@ -138,6 +138,16 @@ const MapRoute = () => {
   const panelLabel =
     currentAlternative?.label || currentScenario?.scenarioName || "Alternative";
   const panelDescription = currentAlternative?.description || "";
+  const choiceOptions = currentScenario
+    ? currentScenario.alternatives.map((alt, idx) => ({
+        id: idx + 1,
+        label: alt.label,
+        description: alt.description,
+        totalTimeMinutes: alt.totalTimeMinutes,
+        isSelected: selectedRouteIndex === idx + 1,
+        recommended: idx === currentScenario.preselectedIndex,
+      }))
+    : [];
   const bounds = useMemo(() => {
     if (!currentScenario) return null;
     const pts = [currentScenario.start, currentScenario.end];
@@ -241,28 +251,31 @@ const MapRoute = () => {
         <ScenarioPanel
           label={panelLabel}
           description={panelDescription}
-          isSelected={selectedRouteIndex !== 0}
-          onToggle={() => {
-            if (selectedRouteIndex !== 0) {
-              setSelectedLabel("default");
-              setSelectedRouteIndex(0);
-            } else {
-              const alt =
-                currentScenario.alternatives[currentScenario.preselectedIndex];
-              setSelectedLabel(alt?.label || "alternative");
-              setSelectedRouteIndex(currentScenario.preselectedIndex + 1);
-            }
-          }}
           onSubmit={handleChoice}
           scenarioNumber={scenarioIndex + 1}
           totalScenarios={scenarios.length}
           defaultTime={defaultTime}
           alternativeTime={
             selectedRouteIndex === 0
-              ? defaultTime
+              ? currentScenario.alternatives[
+                  currentScenario.preselectedIndex
+                ]?.totalTimeMinutes ?? defaultTime
               : currentScenario.alternatives[selectedRouteIndex - 1]?.totalTimeMinutes
           }
           scenarioText={scenarioText}
+          choices={choiceOptions}
+          onToggleRoute={(idx) => {
+            if (!currentScenario) return;
+            if (idx === 0) {
+              setSelectedLabel("default");
+              setSelectedRouteIndex(0);
+              return;
+            }
+
+            const alt = currentScenario.alternatives[idx - 1];
+            setSelectedLabel(alt?.label || "alternative");
+            setSelectedRouteIndex(idx);
+          }}
         />
       )}
     </div>

--- a/src/ScenarioPanel.jsx
+++ b/src/ScenarioPanel.jsx
@@ -3,14 +3,14 @@ import React from "react";
 const ScenarioPanel = ({
   label,
   description,
-  isSelected,
-  onToggle,
   onSubmit,
   scenarioNumber,
   totalScenarios,
   defaultTime,
   alternativeTime,
   scenarioText,
+  choices = [],
+  onToggleRoute,
 }) => {
 
   const line1 = scenarioText?.line1?.replace('{defaultTime}', defaultTime) ||
@@ -33,32 +33,68 @@ const ScenarioPanel = ({
       </div>
 
       <div className="space-y-6">
-
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="font-medium">{label}</p>
-            {description && (
-              <p className="text-xs text-gray-500">{description}</p>
-            )}
+        <div>
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="font-medium">{label}</p>
+              {description && (
+                <p className="text-xs text-gray-500">{description}</p>
+              )}
+            </div>
           </div>
 
-          <label className="inline-flex items-center cursor-pointer">
-            <input
-              type="checkbox"
-              checked={isSelected}
-              onChange={onToggle}
-              className="sr-only peer"
-            />
-            <div
-              className={
-                "w-14 h-7 bg-gray-300 rounded-full relative transition-colors " +
-                "peer-checked:bg-blue-600 " +
-                "after:content-[''] after:absolute after:top-[2px] after:left-[2px] " +
-                "after:w-6 after:h-6 after:bg-white after:rounded-full after:transition-transform " +
-                "peer-checked:after:translate-x-7"
-              }
-            ></div>
-          </label>
+          {choices.length > 0 ? (
+            <div className="mt-4 space-y-4">
+              {choices.map((choice) => (
+                <div
+                  key={choice.id}
+                  className="flex items-start justify-between gap-4"
+                >
+                  <div className="text-sm">
+                    <p className="font-medium text-gray-800">{choice.label}</p>
+                    {choice.description && (
+                      <p className="text-xs text-gray-500 mt-1">
+                        {choice.description}
+                      </p>
+                    )}
+                    <p className="text-xs text-gray-400 mt-1">
+                      Travel time: {choice.totalTimeMinutes} minutes
+                      {choice.recommended && " • Recommended"}
+                    </p>
+                  </div>
+
+                  <label className="inline-flex items-center cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={Boolean(choice.isSelected)}
+                      onChange={(e) => {
+                        if (!onToggleRoute) return;
+                        if (e.target.checked) {
+                          onToggleRoute(choice.id);
+                        } else {
+                          onToggleRoute(0);
+                        }
+                      }}
+                      className="sr-only peer"
+                    />
+                    <div
+                      className={
+                        "w-14 h-7 bg-gray-300 rounded-full relative transition-colors " +
+                        "peer-checked:bg-blue-600 " +
+                        "after:content-[''] after:absolute after:top-[2px] after:left-[2px] " +
+                        "after:w-6 after:h-6 after:bg-white after:rounded-full after:transition-transform " +
+                        "peer-checked:after:translate-x-7"
+                      }
+                    ></div>
+                  </label>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-gray-500 mt-4">
+              No alternative routes available for this scenario.
+            </p>
+          )}
         </div>
 
         <button


### PR DESCRIPTION
## Summary
- render every configured alternative route as its own toggle in the scenario panel
- build choice metadata from the scenario config so UI text and toggles stay in sync with selections
- keep recommended alternative context when default route is active and show travel time hints for each option

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d585bf36748331b7db2c81d2dc4492