### PR TITLE
Fix undefined currentAlternative reference

### DIFF
--- a/src/MapRoute.js
+++ b/src/MapRoute.js
@@ -152,8 +152,8 @@ const MapRoute = () => {
         ] ?? null
       : null;
   const panelLabel =
-    currentAlternative?.label || currentScenario?.scenarioName || "Alternative";
-  const panelDescription = currentAlternative?.description || "";
+    activeAlternative?.label || currentScenario?.scenarioName || "Alternative";
+  const panelDescription = activeAlternative?.description || "";
   const choiceOptions = currentScenario
     ? currentScenario.alternatives.map((alt, idx) => ({
         id: idx + 1,


### PR DESCRIPTION
## Summary
- replace the undefined `currentAlternative` references in MapRoute with the existing `activeAlternative`
- ensure the panel uses the currently selected alternative's label and description safely

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5a0e7fed083318198572a6f6d8dba