### PR TITLE
Add alternative route toggles to scenario panel

### DIFF
--- a/src/MapRoute.js
+++ b/src/MapRoute.js
@@ -138,6 +138,7 @@ const MapRoute = () => {
   const panelLabel =
     currentAlternative?.label || currentScenario?.scenarioName || "Alternative";
   const panelDescription = currentAlternative?.description || "";
+  const panelTime = currentAlternative?.totalTimeMinutes ?? defaultTime;
   const bounds = useMemo(() => {
     if (!currentScenario) return null;
     const pts = [currentScenario.start, currentScenario.end];
@@ -146,6 +147,22 @@ const MapRoute = () => {
     });
     return L.latLngBounds(pts);
   }, [currentScenario]);
+
+  const handleSelectRoute = (index) => {
+    if (!currentScenario) return;
+
+    if (index === 0) {
+      setSelectedLabel("default");
+      setSelectedRouteIndex(0);
+      return;
+    }
+
+    const alt = currentScenario.alternatives[index - 1];
+    if (!alt) return;
+
+    setSelectedLabel(alt?.label || "alternative");
+    setSelectedRouteIndex(index);
+  };
 
   if (error) return <div>{error}</div>;
   if (!routeConfig || scenarios.length === 0 || !bounds)
@@ -177,15 +194,7 @@ const MapRoute = () => {
           alternatives={currentScenario.alternatives}
           defaultTimeMinutes={defaultTime}
           selectedIndex={selectedRouteIndex}
-          setSelectedIndex={(i) => {
-            setSelectedRouteIndex(i);
-            if (i === 0) {
-              setSelectedLabel("default");
-            } else {
-              const alt = currentScenario.alternatives[i - 1];
-              setSelectedLabel(alt?.label || "alternative");
-            }
-          }}
+          setSelectedIndex={handleSelectRoute}
           consentGiven={consentGiven}
           setMapPoints={setMapPoints}
           setRoutes={setRoutes}
@@ -239,30 +248,17 @@ const MapRoute = () => {
 
       {consentGiven && !showOnboarding && (
         <ScenarioPanel
-          label={panelLabel}
-          description={panelDescription}
-          isSelected={selectedRouteIndex !== 0}
-          onToggle={() => {
-            if (selectedRouteIndex !== 0) {
-              setSelectedLabel("default");
-              setSelectedRouteIndex(0);
-            } else {
-              const alt =
-                currentScenario.alternatives[currentScenario.preselectedIndex];
-              setSelectedLabel(alt?.label || "alternative");
-              setSelectedRouteIndex(currentScenario.preselectedIndex + 1);
-            }
-          }}
-          onSubmit={handleChoice}
           scenarioNumber={scenarioIndex + 1}
           totalScenarios={scenarios.length}
           defaultTime={defaultTime}
-          alternativeTime={
-            selectedRouteIndex === 0
-              ? defaultTime
-              : currentScenario.alternatives[selectedRouteIndex - 1]?.totalTimeMinutes
-          }
           scenarioText={scenarioText}
+          activeLabel={panelLabel}
+          activeDescription={panelDescription}
+          activeTime={panelTime}
+          alternatives={currentScenario.alternatives}
+          selectedRouteIndex={selectedRouteIndex}
+          onSelectRoute={handleSelectRoute}
+          onSubmit={handleChoice}
         />
       )}
     </div>

--- a/src/ScenarioPanel.jsx
+++ b/src/ScenarioPanel.jsx
@@ -1,30 +1,36 @@
 import React from "react";
 
 const ScenarioPanel = ({
-  label,
-  description,
-  isSelected,
-  onToggle,
-  onSubmit,
   scenarioNumber,
   totalScenarios,
   defaultTime,
-  alternativeTime,
   scenarioText,
+  activeLabel,
+  activeDescription,
+  activeTime,
+  alternatives,
+  selectedRouteIndex,
+  onSelectRoute,
+  onSubmit,
 }) => {
-
-  const line1 = scenarioText?.line1?.replace('{defaultTime}', defaultTime) ||
-    `The time-efficient route takes approximately ${defaultTime} minutes.`;
-  const line2 = scenarioText?.line2
-    ?.replace('{label}', label)
-    ?.replace('{alternativeTime}', alternativeTime) ||
-    `The ${label} route prioritizes safety and takes about ${alternativeTime} minutes.`;
-  const line3 = scenarioText?.line3
-    ?.replace('{label}', label.toLowerCase()) ||
-    `Use the toggle below to activate the ${label.toLowerCase()} route if you prefer safety over speed.`;
+  const safeLabel = activeLabel || "Alternative";
+  const lowerLabel = safeLabel.toLowerCase();
+  const defaultTimeText = defaultTime ?? "-";
+  const activeTimeText = activeTime ?? defaultTime ?? "-";
+  const line1 =
+    scenarioText?.line1?.replace("{defaultTime}", String(defaultTimeText)) ||
+    `The time-efficient route takes approximately ${defaultTimeText} minutes.`;
+  const line2 =
+    scenarioText?.line2
+      ?.replace("{label}", safeLabel)
+      ?.replace("{alternativeTime}", String(activeTimeText)) ||
+    `The ${safeLabel} route prioritizes safety and takes about ${activeTimeText} minutes.`;
+  const line3 =
+    scenarioText?.line3?.replace("{label}", lowerLabel) ||
+    "Use the toggles below to activate an alternative route if you prefer safety over speed.";
 
   return (
-    <div className="absolute top-5 left-5 w-80 bg-white p-6 rounded-xl shadow-lg z-[1000] text-base text-gray-800 font-sans">
+    <div className="absolute top-5 left-5 w-96 bg-white p-6 rounded-xl shadow-lg z-[1000] text-base text-gray-800 font-sans">
       <p className="font-semibold">Scenario {scenarioNumber} out of {totalScenarios}</p>
       <div className="mt-3 mb-6 p-4 bg-gray-100 rounded-md text-gray-700">
         <p className="mb-2">{line1}</p>
@@ -32,33 +38,74 @@ const ScenarioPanel = ({
         <p className="text-sm">{line3}</p>
       </div>
 
-      <div className="space-y-6">
+      <div className="space-y-4">
+        <div className="text-sm text-gray-600">
+          Default route: <span className="font-medium">{defaultTimeText} minutes</span>
+        </div>
 
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="font-medium">{label}</p>
-            {description && (
-              <p className="text-xs text-gray-500">{description}</p>
-            )}
+        {activeDescription && (
+          <div className="p-3 bg-blue-50 border border-blue-100 rounded-md text-sm text-blue-900">
+            <p className="font-medium mb-1">Currently highlighted: {safeLabel}</p>
+            <p>{activeDescription}</p>
           </div>
+        )}
 
-          <label className="inline-flex items-center cursor-pointer">
-            <input
-              type="checkbox"
-              checked={isSelected}
-              onChange={onToggle}
-              className="sr-only peer"
-            />
-            <div
-              className={
-                "w-14 h-7 bg-gray-300 rounded-full relative transition-colors " +
-                "peer-checked:bg-blue-600 " +
-                "after:content-[''] after:absolute after:top-[2px] after:left-[2px] " +
-                "after:w-6 after:h-6 after:bg-white after:rounded-full after:transition-transform " +
-                "peer-checked:after:translate-x-7"
-              }
-            ></div>
-          </label>
+        <div className="space-y-3">
+          {alternatives.length === 0 ? (
+            <p className="text-sm text-gray-500">No alternative routes configured.</p>
+          ) : (
+            alternatives.map((alt, idx) => {
+              const index = idx + 1;
+              const isSelected = selectedRouteIndex === index;
+              const altTime = alt.totalTimeMinutes ?? "-";
+              const difference =
+                typeof alt.totalTimeMinutes === "number" && typeof defaultTime === "number"
+                  ? alt.totalTimeMinutes - defaultTime
+                  : null;
+              const diffLabel =
+                Number.isFinite(difference) && difference !== 0
+                  ? `${difference > 0 ? "+" : ""}${difference} min`
+                  : null;
+
+              return (
+                <div
+                  key={`${alt.label}-${idx}`}
+                  className={`flex items-center justify-between rounded-lg border px-4 py-3 ${
+                    isSelected ? "border-blue-500 bg-blue-50" : "border-gray-200"
+                  }`}
+                >
+                  <div className="pr-4">
+                    <p className="font-medium text-sm">{alt.label}</p>
+                    {alt.description && (
+                      <p className="text-xs text-gray-500 mt-1">{alt.description}</p>
+                    )}
+                    <p className="text-xs text-gray-600 mt-1">
+                      Estimated time: {altTime} min
+                      {diffLabel && <span className="ml-1">({diffLabel} vs default)</span>}
+                    </p>
+                  </div>
+
+                  <label className="inline-flex items-center cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={isSelected}
+                      onChange={() => onSelectRoute(isSelected ? 0 : index)}
+                      className="sr-only peer"
+                    />
+                    <div
+                      className={
+                        "w-14 h-7 bg-gray-300 rounded-full relative transition-colors " +
+                        "peer-checked:bg-blue-600 " +
+                        "after:content-[''] after:absolute after:top-[2px] after:left-[2px] " +
+                        "after:w-6 after:h-6 after:bg-white after:rounded-full after:transition-transform " +
+                        "peer-checked:after:translate-x-7"
+                      }
+                    ></div>
+                  </label>
+                </div>
+              );
+            })
+          )}
         </div>
 
         <button


### PR DESCRIPTION
## Summary
- share a reusable route-selection handler between the map polylines and the control panel to keep the highlighted path in sync
- expand the scenario panel UI to list every configured alternative with its description and travel time so each route can be toggled individually

## Testing
- npm run build *(fails: Build error occurred [Error: Failed to collect page data for /api/log-survey])*

------
https://chatgpt.com/codex/tasks/task_e_68d5aa4f214c8331bce8b53e46cdc036