### PR TITLE
Ensure default route remains active when toggles are off

### DIFF
--- a/src/MapRoute.js
+++ b/src/MapRoute.js
@@ -67,22 +67,17 @@ const MapRoute = () => {
                 middle: c.middle_point,
                 tts,
                 totalTimeMinutes: defaultTime + tts,
-                preselected: c.preselected,
+                preselected: Boolean(c.preselected),
                 label,
                 description,
               };
             });
-            const preIdx = Math.max(
-              0,
-              alternatives.findIndex((c) => c.preselected)
-            );
             return {
               scenarioName: sc.scenario_name,
               start: sc.start,
               end: sc.end,
               defaultTime,
               alternatives,
-              preselectedIndex: preIdx,
             };
           })
         );
@@ -130,15 +125,21 @@ const MapRoute = () => {
   const { consentText, scenarioText, instructions } = routeConfig || {};
   const currentScenario = scenarios[scenarioIndex];
   const defaultTime = currentScenario?.defaultTime;
-  const currentAlternative = currentScenario
-    ? selectedRouteIndex === 0
-      ? currentScenario.alternatives[currentScenario.preselectedIndex]
-      : currentScenario.alternatives[selectedRouteIndex - 1]
-    : null;
+  const currentAlternative =
+    currentScenario && selectedRouteIndex > 0
+      ? currentScenario.alternatives[selectedRouteIndex - 1]
+      : null;
+
   const panelLabel =
-    currentAlternative?.label || currentScenario?.scenarioName || "Alternative";
-  const panelDescription = currentAlternative?.description || "";
-  const panelTime = currentAlternative?.totalTimeMinutes ?? defaultTime;
+    selectedRouteIndex === 0
+      ? "Default"
+      : currentAlternative?.label || currentScenario?.scenarioName || "Alternative";
+  const panelDescription =
+    selectedRouteIndex === 0 ? "" : currentAlternative?.description || "";
+  const panelTime =
+    selectedRouteIndex === 0
+      ? defaultTime
+      : currentAlternative?.totalTimeMinutes ?? defaultTime;
   const bounds = useMemo(() => {
     if (!currentScenario) return null;
     const pts = [currentScenario.start, currentScenario.end];


### PR DESCRIPTION
## Summary
- build scenario alternatives without carrying a preselected index so the UI can fall back to the default route
- treat an unselected state as the default route in the scenario panel so the default path stays highlighted when all toggles are off

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5aeb6e33c83318d464237887d1ab4