### PR TITLE
Remove default route details from scenario panel

### DIFF
--- a/src/ScenarioPanel.jsx
+++ b/src/ScenarioPanel.jsx
@@ -39,17 +39,6 @@ const ScenarioPanel = ({
       </div>
 
       <div className="space-y-4">
-        <div className="text-sm text-gray-600">
-          Default route: <span className="font-medium">{defaultTimeText} minutes</span>
-        </div>
-
-        {activeDescription && (
-          <div className="p-3 bg-blue-50 border border-blue-100 rounded-md text-sm text-blue-900">
-            <p className="font-medium mb-1">Currently highlighted: {safeLabel}</p>
-            <p>{activeDescription}</p>
-          </div>
-        )}
-
         <div className="space-y-3">
           {alternatives.length === 0 ? (
             <p className="text-sm text-gray-500">No alternative routes configured.</p>


### PR DESCRIPTION
## Summary
- remove the default route time line from the scenario panel sidebar
- remove the highlighted route description callout block from the scenario panel

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5b0f61aac83318c19232aff913514