### PR TITLE
Update scenario instructions handling

### DIFF
--- a/app/api/route-endpoints/route.js
+++ b/app/api/route-endpoints/route.js
@@ -98,7 +98,7 @@ export async function GET() {
       scenarios: rawScenarios,
       settings,
       consentText: textsConfig?.consentText ?? '',
-      scenarioText: textsConfig?.scenarioText ?? {},
+      scenarioText: typeof textsConfig?.scenarioText === 'string' ? textsConfig.scenarioText : '',
       instructions: Array.isArray(instructionsConfig?.steps) ? instructionsConfig.steps : [],
       survey: Array.isArray(surveyConfig?.survey) ? surveyConfig.survey : [],
       publicScenarios,
@@ -174,8 +174,8 @@ export async function POST(req) {
     if ('consentText' in body && typeof body.consentText !== 'string') {
       return NextResponse.json({ error: 'consentText must be a string' }, { status: 400 });
     }
-    if ('scenarioText' in body && (typeof body.scenarioText !== 'object' || body.scenarioText === null)) {
-      return NextResponse.json({ error: 'scenarioText must be an object' }, { status: 400 });
+    if ('scenarioText' in body && typeof body.scenarioText !== 'string') {
+      return NextResponse.json({ error: 'scenarioText must be a string' }, { status: 400 });
     }
 
     const existingTexts = clone((await get('textsConfig')) || {});

--- a/src/ScenarioPanel.jsx
+++ b/src/ScenarioPanel.jsx
@@ -14,28 +14,31 @@ const ScenarioPanel = ({
   onSubmit,
 }) => {
   const safeLabel = activeLabel || "Alternative";
-  const lowerLabel = safeLabel.toLowerCase();
-  const defaultTimeText = defaultTime ?? "-";
-  const activeTimeText = activeTime ?? defaultTime ?? "-";
-  const line1 =
-    scenarioText?.line1?.replace("{defaultTime}", String(defaultTimeText)) ||
-    `The time-efficient route takes approximately ${defaultTimeText} minutes.`;
-  const line2 =
-    scenarioText?.line2
-      ?.replace("{label}", safeLabel)
-      ?.replace("{alternativeTime}", String(activeTimeText)) ||
-    `The ${safeLabel} route prioritizes safety and takes about ${activeTimeText} minutes.`;
-  const line3 =
-    scenarioText?.line3?.replace("{label}", lowerLabel) ||
-    "Use the toggles below to activate an alternative route if you prefer safety over speed.";
+  const defaultScenarioText =
+    "The time-efficient route takes approximately 25 minutes.\n\n" +
+    "The Default route prioritizes safety and takes about 25 minutes.\n\n" +
+    "Use the toggle below to activate the default route if you prefer safety over speed.";
+  const scenarioDescription =
+    typeof scenarioText === "string" && scenarioText.trim().length > 0
+      ? scenarioText
+      : defaultScenarioText;
+  const paragraphs = scenarioDescription
+    .split(/\n+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
 
   return (
     <div className="absolute top-5 left-5 w-96 bg-white p-6 rounded-xl shadow-lg z-[1000] text-base text-gray-800 font-sans">
       <p className="font-semibold">Scenario {scenarioNumber} out of {totalScenarios}</p>
       <div className="mt-3 mb-6 p-4 bg-gray-100 rounded-md text-gray-700">
-        <p className="mb-2">{line1}</p>
-        <p className="mb-2">{line2}</p>
-        <p className="text-sm">{line3}</p>
+        {paragraphs.map((text, index) => (
+          <p
+            key={`${text}-${index}`}
+            className={index === paragraphs.length - 1 ? "text-sm" : "mb-2"}
+          >
+            {text}
+          </p>
+        ))}
       </div>
 
       <div className="space-y-4">

--- a/src/admin/TextsEditor.jsx
+++ b/src/admin/TextsEditor.jsx
@@ -19,8 +19,7 @@ export default function TextsEditor() {
       })
       .then((data) => {
         setConsentText(data.consentText || "");
-        const st = data.scenarioText || { line1: "", line2: "", line3: "" };
-        setScenarioText([st.line1, st.line2, st.line3].filter(Boolean).join("\n"));
+        setScenarioText(typeof data.scenarioText === "string" ? data.scenarioText : "");
         setError("");
       })
       .catch((e) => setError(e.message))
@@ -31,17 +30,11 @@ export default function TextsEditor() {
     setSaving(true);
     setError("");
     try {
-      const lines = scenarioText.split("\n");
-      const scenarioObj = {
-        line1: lines[0] || "",
-        line2: lines[1] || "",
-        line3: lines[2] || "",
-      };
       const res = await fetch(API_URL, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ consentText, scenarioText: scenarioObj }),
+        body: JSON.stringify({ consentText, scenarioText }),
       });
       if (!res.ok) throw new Error(`Failed to save (${res.status})`);
     } catch (e) {
@@ -57,8 +50,7 @@ export default function TextsEditor() {
       .then((r) => r.json())
       .then((data) => {
         setConsentText(data.consentText || "");
-        const st = data.scenarioText || { line1: "", line2: "", line3: "" };
-        setScenarioText([st.line1, st.line2, st.line3].filter(Boolean).join("\n"));
+        setScenarioText(typeof data.scenarioText === "string" ? data.scenarioText : "");
       })
       .finally(() => setLoading(false));
   };


### PR DESCRIPTION
## Summary
- update the scenario panel to show a static default message and render any provided scenario text as simple paragraphs
- allow the admin text editor to load and save the scenario text as a plain string
- adjust the route endpoint API to read and validate the scenario text as a string value

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5b50a617c83318059b6d640b560a0