### PR TITLE
Add dropdown for instruction example selection

### DIFF
--- a/src/admin/InstructionsEditor.jsx
+++ b/src/admin/InstructionsEditor.jsx
@@ -3,6 +3,12 @@ import { withBasePath } from "../utils/basePath";
 
 const API_URL = withBasePath("/api/route-endpoints");
 
+const exampleOptions = [
+  { value: "", label: "No example" },
+  { value: "switch", label: "Toggle switch" },
+  { value: "button", label: "Confirmation button" },
+];
+
 const emptyStep = () => ({ title: "", lines: [""], example: "" });
 
 export default function InstructionsEditor() {
@@ -123,12 +129,17 @@ export default function InstructionsEditor() {
             </div>
             <div>
               <label className="block text-sm font-medium mb-1">Example (optional)</label>
-              <input
-                type="text"
+              <select
                 value={steps[selected].example || ""}
                 onChange={(e) => handleStepChange(selected, { example: e.target.value })}
                 className="w-full border rounded px-2 py-1 text-sm"
-              />
+              >
+                {exampleOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
             </div>
             <button
               onClick={() => deleteStep(selected)}


### PR DESCRIPTION
## Summary
- replace the instructions editor example text field with a dropdown of supported examples
- define explicit options for no example, the toggle switch demo, and the confirmation button demo

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5b5dda1108331b0ae2c9d2d67061f