### PR TITLE
Render scenario text uniformly

### DIFF
--- a/src/ScenarioPanel.jsx
+++ b/src/ScenarioPanel.jsx
@@ -22,23 +22,11 @@ const ScenarioPanel = ({
     typeof scenarioText === "string" && scenarioText.trim().length > 0
       ? scenarioText
       : defaultScenarioText;
-  const paragraphs = scenarioDescription
-    .split(/\n+/)
-    .map((part) => part.trim())
-    .filter(Boolean);
-
   return (
     <div className="absolute top-5 left-5 w-96 bg-white p-6 rounded-xl shadow-lg z-[1000] text-base text-gray-800 font-sans">
       <p className="font-semibold">Scenario {scenarioNumber} out of {totalScenarios}</p>
       <div className="mt-3 mb-6 p-4 bg-gray-100 rounded-md text-gray-700">
-        {paragraphs.map((text, index) => (
-          <p
-            key={`${text}-${index}`}
-            className={index === paragraphs.length - 1 ? "text-sm" : "mb-2"}
-          >
-            {text}
-          </p>
-        ))}
+        <p>{scenarioDescription}</p>
       </div>
 
       <div className="space-y-4">


### PR DESCRIPTION
## Summary
- stop splitting scenario text into multiple paragraphs in the left panel
- render the full scenario description string with a single consistent style

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5b8b993408331bb96b5fac0da9025