### PR TITLE
Fix scenario creation after deletions

### DIFF
--- a/src/admin/ScenariosEditor.jsx
+++ b/src/admin/ScenariosEditor.jsx
@@ -533,7 +533,20 @@ export default function ScenariosEditor() {
 
   const addScenario = () => {
     const prev = selectedKey ? scenarios[selectedKey] : null;
-    const nextIndex = scenarioKeys.length + 1;
+
+    const usedIndexes = new Set(
+      scenarioKeys
+        .map((key) => {
+          const match = /^scenario_(\d+)$/.exec(key);
+          return match ? Number.parseInt(match[1], 10) : null;
+        })
+        .filter((value) => Number.isInteger(value) && value > 0)
+    );
+
+    let nextIndex = 1;
+    while (usedIndexes.has(nextIndex)) {
+      nextIndex += 1;
+    }
 
     const cloneScenario = (sc) =>
       typeof structuredClone === "function"


### PR DESCRIPTION
## Summary
- ensure new scenario keys use the first unused index instead of relying on the count
- keep scenario cloning and selection logic unchanged while guaranteeing unique keys

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5bb0f932483318af36b47d481d860